### PR TITLE
README.md: More than 3 auth backends now

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ Configuration is accessed by clicking on the configuration cog on the login page
 ## Vault Endpoint
 Users can enter in the full endpoint to Vault, including scheme.
 ## Authentication
-There are currently three supported authentication backends. [Github](https://www.vaultproject.io/docs/auth/github.html), [Username and Password](https://www.vaultproject.io/docs/auth/userpass.html), [LDAP](https://www.vaultproject.io/docs/auth/ldap.html), and [Token](https://www.vaultproject.io/docs/auth/token.html). 
-![Auth Backend](https://github.com/djenriquez/vault-ui/raw/master/images/AuthConfig.png)
+Currently supported authentication backends:
+- [GitHub](https://www.vaultproject.io/docs/auth/github.html)
+- [Username & Password](https://www.vaultproject.io/docs/auth/userpass.html)
+- [LDAP](https://www.vaultproject.io/docs/auth/ldap.html)
+- [Tokens](https://www.vaultproject.io/docs/auth/token.html)
 
 ## Secrets
 By default, secrets will display as their raw JSON value represented by the `data` field in the HTTP GET response metadata. However, users can apply a "Root Key" bias to the secrets through the settings page. The "Root Key" will be used when reading, creating and updating secrets such that the value displayed in the UI is the value stored at the "Root Key". For example, if the secret at `secret/hello` is `{ "value": "world" }`, setting the "Root Key" to `value` will update the UI such that the secret will display as simply "world" instead of `{ "value": "world" }`.


### PR DESCRIPTION
but instead of just updating from 3 to 4, I took out the number to prevent future mistakes and also made it a bulleted list, which I think is more readable, and made the names exactly match the Vault docs.

https://github.com/msabramo/vault-ui/blob/patch-1/README.md#authentication