### PR TITLE
Display Root Key setting in New Key dialog

### DIFF
--- a/app/components/Secrets/Secrets.jsx
+++ b/app/components/Secrets/Secrets.jsx
@@ -225,6 +225,14 @@ class Secrets extends React.Component {
             <FlatButton label="Submit" primary={true} onTouchTap={validateAndSubmit} />
         ];
 
+        var rootKeyInfo;
+
+        if (this.state.useRootKey) {
+          rootKeyInfo = "Current Root Key: " + this.state.rootKey;
+        } else {
+          rootKeyInfo = "No Root Key set. Value must be JSON.";
+        }
+
         return (
             <Dialog
                 title={`New Key`}
@@ -242,6 +250,7 @@ class Secrets extends React.Component {
                     hintText="Value"
                     onChange={this.secretChanged} />
                 <div className={styles.error}>{this.state.errorMessage}</div>
+                <div>{rootKeyInfo}</div>
             </Dialog>
         );
     }


### PR DESCRIPTION
If Root Key is set, then display it.

![screen shot 2016-12-04 at 1 32 11 am](https://cloud.githubusercontent.com/assets/305268/20865232/85153810-b9c1-11e6-95ec-d78b1cb11ff9.png)

If it's not, then say that it's not set and that JSON is required.

![screen shot 2016-12-04 at 1 32 41 am](https://cloud.githubusercontent.com/assets/305268/20865236/95c5cda0-b9c1-11e6-9677-2af02e23ee8e.png)

I wonder if this also helps with with the issue I brought up in #17.