### PR TITLE
docker-compose.yaml: /app/node_modules volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,9 +18,11 @@ services:
       - vault
     volumes:
       - .:/app
+      - /app/node_modules
 
   webpack:
     build: .
     volumes:
       - .:/app
+      - /app/node_modules
     command: webpack -w


### PR DESCRIPTION
This prevents a problem that the Docker containers would fail because of
missing dependencies if you didn't run `npm install` on the host,
because the `node_modules` directory on the host was overshadowing the
one inside the container. E.g.:

```
$ docker-compose logs -f vault-ui
Attaching to vaultui_vault-ui_1
vault-ui_1  | npm info it worked if it ends with ok
vault-ui_1  | npm info using npm@3.10.9
vault-ui_1  | npm info using node@v7.2.0
vault-ui_1  | npm info lifecycle vault_ui@1.0.0~preserve: vault_ui@1.0.0
vault-ui_1  | npm info lifecycle vault_ui@1.0.0~serve: vault_ui@1.0.0
vault-ui_1  |
vault-ui_1  | > vault_ui@1.0.0 serve /app
vault-ui_1  | > nodemon ./server.js
vault-ui_1  |
vault-ui_1  | sh: 1: nodemon: not found
...
```

Fix inspired by http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html#the-nodemodules-volume-trick