### PR TITLE
Show only last root token in docker-compose log

### DIFF
--- a/run-docker-compose-dev
+++ b/run-docker-compose-dev
@@ -20,4 +20,4 @@ exec_in_vault vault policy-write admin /app/admin.hcl
 exec_in_vault vault write auth/userpass/users/test password=test policies=admin
 
 echo "------------- Vault Root Token -------------"
-docker-compose logs vault | grep 'Root Token:'
+docker-compose logs vault | grep 'Root Token:' | tail -n 1


### PR DESCRIPTION
Prevents showing multiple root tokens -- e.g.:

```
$ ./run-docker-compose-dev
...
------------- Vault Root Token -------------
vault_1     | Root Token: 8e1cdf31-b1c8-97a5-f0c7-269107cdb1f2
vault_1     | Root Token: 646ac4b0-3848-7614-fb51-c3b991a18378
vault_1     | Root Token: 875b86aa-4da9-4fdf-ec52-c9975545b5f6
```