### PR TITLE
Default URL from env variable

### DIFF
--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -19,7 +19,7 @@ export default class Login extends React.Component {
             show: false,
             openSettings: false,
             authToken: "",
-            vaultUrl: window.localStorage.getItem("vaultUrl") || window.defaultUrl || "",
+            vaultUrl: window.localStorage.getItem("vaultUrl") || window.defaultUrl,
             tmpVaultUrl: "",
             errorMessage: "",
             username: "",

--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -19,7 +19,7 @@ export default class Login extends React.Component {
             show: false,
             openSettings: false,
             authToken: "",
-            vaultUrl: window.localStorage.getItem("vaultUrl") || "",
+            vaultUrl: window.localStorage.getItem("vaultUrl") || window.defaultUrl || "",
             tmpVaultUrl: "",
             errorMessage: "",
             username: "",

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     </head>
     <body>
         <div id="app"></div>
+        <script>window.defaultUrl = "{{defaultUrl}}"</script>
         <script src="/assets/bundle.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "body-parser": "^1.15.2",
     "copy-to-clipboard": "^3.0.5",
     "express": "^4.14.0",
+    "hbs": "^4.0.1",
     "hcl-to-json": "0.0.4",
     "lodash": "^4.16.6",
     "material-ui": "^0.16.1",

--- a/server.js
+++ b/server.js
@@ -8,9 +8,11 @@ var _ = require('lodash');
 var routeHandler = require('./src/routeHandler');
 
 var PORT = 8000;
+var VAULT_URL_DEFAULT = process.env.VAULT_URL_DEFAULT;
 
 var app = express();
-app.set('view engine', '.html');
+app.set('view engine', 'html');
+app.engine('html', require('hbs').__express);
 app.use('/assets', express.static('dist'));
 
 // parse application/x-www-form-urlencoded
@@ -84,5 +86,5 @@ app.post('/unwrap', function(req, res) {
 app.get('/');
 
 app.get('*', function (req, res) {
-    res.sendFile(path.join(__dirname, '/index.html'));
+    res.render(path.join(__dirname, '/index.html'),{defaultUrl: VAULT_URL_DEFAULT});
 });

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var _ = require('lodash');
 var routeHandler = require('./src/routeHandler');
 
 var PORT = 8000;
-var VAULT_URL_DEFAULT = process.env.VAULT_URL_DEFAULT;
+var VAULT_URL_DEFAULT = process.env.VAULT_URL_DEFAULT || "";
 
 var app = express();
 app.set('view engine', 'html');


### PR DESCRIPTION
If an environment variable of `VAULT_URL_DEFAULT` is specified, and the user has not set a local vaultUrl, the URL will automatically be the value of the environment variable.  Defaults to empty string in case the docker image does not specify such a variable.

This work was done in response to issue https://github.com/djenriquez/vault-ui/issues/28