### PR TITLE
Fix timeout issue on long leases

### DIFF
--- a/app/components/App/App.jsx
+++ b/app/components/App/App.jsx
@@ -51,7 +51,8 @@ export default class App extends React.Component {
         let logoutTimeout = () => {
             browserHistory.push('/login');
         }
-        if (tokenExpireDate >= 0) {
+        // The upper limit of setTimeout is 0x7FFFFFFF (or 2147483647 in decimal)
+        if (tokenExpireDate >= 0 && tokenExpireDate < 2147483648) {
             setTimeout(logoutTimeout, tokenExpireDate);
             setTimeout(twoMinuteWarningTimeout, tokenExpireDate - TWO_MINUTES);
         }


### PR DESCRIPTION
If vault returns a large lease for a user, setTimeout will return immediately and the user will always be presented with the login screen.