### PR TITLE
Fix script to authenticate first

### DIFF
--- a/run-docker-compose-dev
+++ b/run-docker-compose-dev
@@ -14,6 +14,7 @@ exec_in_vault() {
   echo
 }
 
+exec_in_vault vault auth "$(docker-compose logs vault | grep 'Root Token:' | tail -n 1 | awk '{ print $NF }')"
 exec_in_vault vault status
 exec_in_vault vault auth-enable userpass
 exec_in_vault vault policy-write admin /app/admin.hcl


### PR DESCRIPTION
We need to authenticate first before running other `vault` commands to enable `userpass` and write policies.

If we do not authenticate, script fails below errors. Let me know if you have any questions. Thanks.
```bash
------------- vault auth-enable userpass -------------

▽
#!/bin/sh
Error: Error making API request.

URL: POST http://127.0.0.1:8200/v1/sys/auth/userpass
Code: 400. Errors:

* missing client token

------------- vault policy-write admin /app/admin.hcl -------------
Error: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/policy/admin
Code: 400. Errors:

* missing client token


▽
---
------------- vault write auth/userpass/users/test password=test policies=admin -------------
Error writing data to auth/userpass/users/test: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/auth/userpass/users/test
Code: 400. Errors:

* missing client token
``` 