### PR TITLE
Allow a request header to be used to provide the auth token

### DIFF
--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -39,6 +39,14 @@ export default class Login extends React.Component {
             'validateUsernamePassword',
             'checkSettings'
         )
+
+        // If a token was supplied in the window.suppliedAuthToken variable, then simulate a login
+        if ( window.suppliedAuthToken && this.state.vaultUrl ) {
+            this.state.loginMethodType = 'TOKEN';
+            this.state.authToken = window.suppliedAuthToken;
+            this.validateToken({keyCode: 13});
+        }
+
     }
 
     componentDidMount() {
@@ -47,13 +55,6 @@ export default class Login extends React.Component {
             this.setState({
                 openSettings: true
             });
-        } else {
-            // If a token was supplied in the window.suppliedAuthToken variable, then simulate a login
-            if ( window.suppliedAuthToken ) {
-                this.setState({loginMethodType: 'TOKEN', authToken: window.suppliedAuthToken}, function () {
-                    this.validateToken({keyCode: 13, tokenSupplied: true});
-                });
-            }
         }
     }
 
@@ -120,10 +121,10 @@ export default class Login extends React.Component {
                 })
                 .catch((err) => {
                     console.error(err.stack);
-                    this.setState({ errorMessage: err.response.data, loginMethodType: this.getVaultAuthMethod() })
-                    if ( e.hasOwnProperty('tokenSupplied') ) {
-                        this.setState({ errorMessage: err.response.data + ". Login was attempted using a server supplied token. Please contact your network administrator." })
-                    }
+                    this.setState({
+                        errorMessage: `${window.suppliedAuthToken ? 'Login was attempted using a server supplied token. Please contact your network administrator. -- ' :  ''}${err.response.data}`,
+                        loginMethodType: this.getVaultAuthMethod()
+                    });
                 });
         }
     }

--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -47,6 +47,13 @@ export default class Login extends React.Component {
             this.setState({
                 openSettings: true
             });
+        } else {
+          // If a token was supplied in the window.suppliedAuthToken, simulate a login
+          if ( window.suppliedAuthToken ) {
+            this.setState({loginMethodType: 'TOKEN', authToken: window.suppliedAuthToken}, function () {
+                this.validateToken({keyCode: 13});
+            });
+          }
         }
     }
 

--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -48,10 +48,10 @@ export default class Login extends React.Component {
                 openSettings: true
             });
         } else {
-            // If a token was supplied in the window.suppliedAuthToken, simulate a login
+            // If a token was supplied in the window.suppliedAuthToken variable, then simulate a login
             if ( window.suppliedAuthToken ) {
                 this.setState({loginMethodType: 'TOKEN', authToken: window.suppliedAuthToken}, function () {
-                    this.validateToken({keyCode: 13});
+                    this.validateToken({keyCode: 13, tokenSupplied: true});
                 });
             }
         }
@@ -120,7 +120,10 @@ export default class Login extends React.Component {
                 })
                 .catch((err) => {
                     console.error(err.stack);
-                    this.setState({ errorMessage: err.response.data })
+                    this.setState({ errorMessage: err.response.data, loginMethodType: this.getVaultAuthMethod() })
+                    if ( e.hasOwnProperty('tokenSupplied') ) {
+                        this.setState({ errorMessage: err.response.data + ". Login was attempted using a server supplied token. Please contact your network administrator." })
+                    }
                 });
         }
     }

--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -48,12 +48,12 @@ export default class Login extends React.Component {
                 openSettings: true
             });
         } else {
-          // If a token was supplied in the window.suppliedAuthToken, simulate a login
-          if ( window.suppliedAuthToken ) {
-            this.setState({loginMethodType: 'TOKEN', authToken: window.suppliedAuthToken}, function () {
-                this.validateToken({keyCode: 13});
-            });
-          }
+            // If a token was supplied in the window.suppliedAuthToken, simulate a login
+            if ( window.suppliedAuthToken ) {
+                this.setState({loginMethodType: 'TOKEN', authToken: window.suppliedAuthToken}, function () {
+                    this.validateToken({keyCode: 13});
+                });
+            }
         }
     }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,8 @@ services:
       - /app/node_modules
     environment:
       VAULT_URL_DEFAULT: http://vault:8200
-      VAULT_AUTH_DEFAULT: USERNAMEPASSWORD
+      VAULT_AUTH_DEFAULT: 'TOKEN'
+      VAULT_SUPPLIED_TOKEN_HEADER: 'X-Remote-User'
 
   webpack:
     build: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - /app/node_modules
     environment:
       VAULT_URL_DEFAULT: http://vault:8200
-      VAULT_AUTH_DEFAULT: 'TOKEN'
+      VAULT_AUTH_DEFAULT: USERNAMEPASSWORD
       VAULT_SUPPLIED_TOKEN_HEADER: 'X-Remote-User'
 
   webpack:

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <div id="app"></div>
         <script>window.defaultUrl = "{{defaultUrl}}"</script>
         <script>window.defaultAuth = "{{defaultAuth}}"</script>
+        <script>window.suppliedAuthToken = "{{suppliedAuthToken}}"</script>
         <script src="/assets/bundle.js"></script>
     </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -97,8 +97,8 @@ app.get('/');
 
 app.get('*', function (req, res) {
     res.render(path.join(__dirname, '/index.html'),{
-      defaultUrl: VAULT_URL_DEFAULT,
-      defaultAuth: VAULT_AUTH_DEFAULT,
-      suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER ? req.header(VAULT_SUPPLIED_TOKEN_HEADER) : ""
+        defaultUrl: VAULT_URL_DEFAULT,
+        defaultAuth: VAULT_AUTH_DEFAULT,
+        suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER ? req.header(VAULT_SUPPLIED_TOKEN_HEADER) : ""
     });
 });

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var routeHandler = require('./src/routeHandler');
 var PORT = 8000;
 var VAULT_URL_DEFAULT = process.env.VAULT_URL_DEFAULT || "";
 var VAULT_AUTH_DEFAULT = process.env.VAULT_AUTH_DEFAULT || "GITHUB";
-var VAULT_SUPPLIED_TOKEN_HEADER = process.env.VAULT_SUPPLIED_TOKEN_HEADER || undefined;
+var VAULT_SUPPLIED_TOKEN_HEADER = process.env.VAULT_SUPPLIED_TOKEN_HEADER
 
 var app = express();
 app.set('view engine', 'html');

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ var routeHandler = require('./src/routeHandler');
 var PORT = 8000;
 var VAULT_URL_DEFAULT = process.env.VAULT_URL_DEFAULT || "";
 var VAULT_AUTH_DEFAULT = process.env.VAULT_AUTH_DEFAULT || "GITHUB";
+var VAULT_SUPPLIED_TOKEN_HEADER = process.env.VAULT_SUPPLIED_TOKEN_HEADER || undefined;
 
 var app = express();
 app.set('view engine', 'html');
@@ -95,5 +96,9 @@ app.post('/unwrap', function(req, res) {
 app.get('/');
 
 app.get('*', function (req, res) {
-    res.render(path.join(__dirname, '/index.html'),{defaultUrl: VAULT_URL_DEFAULT, defaultAuth: VAULT_AUTH_DEFAULT});
+    res.render(path.join(__dirname, '/index.html'),{
+      defaultUrl: VAULT_URL_DEFAULT,
+      defaultAuth: VAULT_AUTH_DEFAULT,
+      suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER ? req.header(VAULT_SUPPLIED_TOKEN_HEADER) : ""
+    });
 });


### PR DESCRIPTION
This PR is experimental and is meant to address #39 

Introduce the `VAULT_SUPPLIED_TOKEN_HEADER` server environment variable.

The above variable will instruct the server to lookup in the specified request header for the authentication token.
Combined with the already supported `VAULT_URL_DEFAULT` and `VAULT_AUTH_DEFAULT` env vars, it can be used to enable login with no user interaction.
