### PR TITLE
Support for custom mountpoint on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,19 @@ Configuration is accessed by clicking on the configuration cog on the login page
 
 ### Vault Endpoint
 Users can enter in the full endpoint to Vault, including scheme.  When running the docker image, it is possible to
-set the environment variables `VAULT_URL_DEFAULT` and `VAULT_AUTH_DEFAULT`.
-`VAULT_URL_DEFAULT` will set the default endpoint for users without needing them to enter one in the UI.
-`VAULT_AUTH_DEFAULT` will set the default authentication method type. Supported values are: GITHUB, TOKEN, LDAP, USERNAMEPASSWORD
+set the following environment variables to pre-configure authentication settings:
+- `VAULT_URL_DEFAULT` will set the default vault endpoint.
+- `VAULT_AUTH_DEFAULT` will set the default authentication method type. See below for supported authentication methods.
+- `VAULT_AUTH_BACKEND_PATH` will set the default backend path. Useful when multiple backends of the same type are mounted on the vault file system.
+
 This defaults can be overridden if the user fills out the endpoint and auth method manually.
 
 ## Authentication
-Currently supported authentication backends:
-- [GitHub](https://www.vaultproject.io/docs/auth/github.html)
-- [Username & Password](https://www.vaultproject.io/docs/auth/userpass.html)
-- [LDAP](https://www.vaultproject.io/docs/auth/ldap.html)
-- [Tokens](https://www.vaultproject.io/docs/auth/token.html)
+Currently supported authentication methods:
+- `GITHUB` : When using the [GitHub](https://www.vaultproject.io/docs/auth/github.html) backend
+- `USERNAMEPASSWORD` : When using the [Username & Password](https://www.vaultproject.io/docs/auth/userpass.html) or [RADIUS](https://www.vaultproject.io/docs/auth/radius.html) backends
+- `LDAP` : When using the [LDAP](https://www.vaultproject.io/docs/auth/ldap.html) backend
+- `TOKEN` : When using the [Tokens](https://www.vaultproject.io/docs/auth/token.html) backend
 
 ### Token authentication by header (SSO)
 In some cases, users might want to use middleware to authenticate into Vault-UI for purposes like SSO. In this case, the `VAULT_SUPPLIED_TOKEN_HEADER` may be populated with the name of the header that contains a token to be used for authentication.

--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -7,6 +7,7 @@ import Dialog from 'material-ui/Dialog';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import FlatButton from 'material-ui/FlatButton';
+import { Card, CardHeader, CardText } from 'material-ui/Card';
 import _ from 'lodash';
 import { callVaultApi } from '../shared/VaultUtils.jsx'
 
@@ -295,14 +296,19 @@ export default class Login extends React.Component {
                     </SelectField>
                 </div>
                 <div>
-                    <TextField
-                        style={{ paddingLeft: 8 }}
-                        id="backendPath"
-                        floatingLabelFixed={true}
-                        floatingLabelText="Auth backend path"
-                        value={this.state.tmpAuthBackendPath}
-                        onChange={(e, v) => this.setState({ tmpAuthBackendPath: v, settingsChanged: true })}
-                    />
+                    <Card initiallyExpanded={false}>
+                        <CardHeader title="Advanced Options" actAsExpander={true} showExpandableButton={true} />
+                        <CardText expandable={true}>
+                            <TextField
+                                style={{ paddingLeft: 8 }}
+                                id="backendPath"
+                                floatingLabelFixed={true}
+                                floatingLabelText="Auth backend path"
+                                value={this.state.tmpAuthBackendPath}
+                                onChange={(e, v) => this.setState({ tmpAuthBackendPath: v, settingsChanged: true })}
+                            />
+                        </CardText>
+                    </Card>
                 </div>
                 <div className={styles.error}>{this.state.errorMessage}</div>
             </Dialog>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         <script>window.defaultUrl = "{{defaultUrl}}"</script>
         <script>window.defaultAuth = "{{defaultAuth}}"</script>
         <script>window.suppliedAuthToken = "{{suppliedAuthToken}}"</script>
+        <script>window.defaultBackendPath = "{{defaultBackendPath}}"</script>
         <script src="/assets/bundle.js"></script>
     </body>
 </html>

--- a/run-docker-compose-dev
+++ b/run-docker-compose-dev
@@ -17,10 +17,12 @@ exec_in_vault() {
 exec_in_vault vault auth "$(docker-compose logs vault | grep 'Root Token:' | tail -n 1 | awk '{ print $NF }')"
 exec_in_vault vault status
 exec_in_vault vault auth-enable userpass
+exec_in_vault vault auth-enable -path=userpass2 userpass
 exec_in_vault vault auth-enable github
 exec_in_vault vault auth-enable -path=awsaccount1 aws-ec2
 exec_in_vault vault policy-write admin /app/admin.hcl
 exec_in_vault vault write auth/userpass/users/test password=test policies=admin
+exec_in_vault vault write auth/userpass2/users/john password=doe policies=admin
 exec_in_vault vault write auth/userpass/users/lame password=lame policies=default
 exec_in_vault vault write secret/test somekey=somedata
 exec_in_vault vault mount -path=ultrasecret generic

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ var PORT = 8000;
 var VAULT_URL_DEFAULT = process.env.VAULT_URL_DEFAULT || "";
 var VAULT_AUTH_DEFAULT = process.env.VAULT_AUTH_DEFAULT || "GITHUB";
 var VAULT_SUPPLIED_TOKEN_HEADER = process.env.VAULT_SUPPLIED_TOKEN_HEADER
+var VAULT_AUTH_BACKEND_PATH = process.env.VAULT_AUTH_BACKEND_PATH
 
 var app = express();
 app.set('view engine', 'html');
@@ -52,6 +53,7 @@ app.get('*', function (req, res) {
     res.render(path.join(__dirname, '/index.html'),{
         defaultUrl: VAULT_URL_DEFAULT,
         defaultAuth: VAULT_AUTH_DEFAULT,
-        suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER ? req.header(VAULT_SUPPLIED_TOKEN_HEADER) : ""
+        suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER ? req.header(VAULT_SUPPLIED_TOKEN_HEADER) : "",
+        defaultBackendPath: VAULT_AUTH_BACKEND_PATH
     });
 });


### PR DESCRIPTION
In Vault it's possible to mount an authentication backend on a non-standard path (example: `userpass` backend mounted on `auth/employees`).

This PR adds support for specifying a custom path in the login settings dialog.

In addition a custom path can be pre-configured by a system administrator with the  `VAULT_AUTH_BACKEND_PATH` environment variable.