### PR TITLE
[WIP] Be able to run ui under a prefix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
         "no-this-before-super": "warn",
         "no-undef": "warn",
         "no-unreachable": "warn",
-        "no-unused-vars": "warn",
+        "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
         "constructor-super": "warn",
         "valid-typeof": "warn",
         "no-console": 0

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
         <title>Vault UI</title>
         <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet">
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/flexboxgrid/6.3.1/flexboxgrid.min.css" type="text/css" >
-        <link href="/assets/styles.css" rel="stylesheet">
+        <link href="{{httpPrefix}}/assets/styles.css" rel="stylesheet">
         <link rel="shortcut icon" href="https://www.vaultproject.io/assets/images/favicon-16466d1a.png" type="image/x-icon">
         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
         <style type="text/css">
@@ -21,6 +21,6 @@
         <script>window.defaultAuth = "{{defaultAuth}}"</script>
         <script>window.suppliedAuthToken = "{{suppliedAuthToken}}"</script>
         <script>window.defaultBackendPath = "{{defaultBackendPath}}"</script>
-        <script src="/assets/bundle.js"></script>
+        <script src="{{httpPrefix}}/assets/bundle.js"></script>
     </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.post('/unwrap', function(req, res) {
     routeHandler.unwrapValue(req, res);
 })
 
-app.all('/v1/*', function(req, res, next) {
+app.all('/v1/*', function(req, res, _next) {
     routeHandler.vaultapi(req, res);
 })
 

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ var routeHandler = require('./src/routeHandler');
 var compression = require('compression');
 
 var PORT = 8000;
+var HTTP_PREFIX = process.env.HTTP_PREFIX || "/";
 var VAULT_URL_DEFAULT = process.env.VAULT_URL_DEFAULT || "";
 var VAULT_AUTH_DEFAULT = process.env.VAULT_AUTH_DEFAULT || "GITHUB";
 var VAULT_SUPPLIED_TOKEN_HEADER = process.env.VAULT_SUPPLIED_TOKEN_HEADER
@@ -17,7 +18,7 @@ var VAULT_AUTH_BACKEND_PATH = process.env.VAULT_AUTH_BACKEND_PATH
 var app = express();
 app.set('view engine', 'html');
 app.engine('html', require('hbs').__express);
-app.use('/assets', compression(), express.static('dist'));
+app.use(prefixPath('/assets'), compression(), express.static('dist'));
 
 // parse application/x-www-form-urlencoded
 app.use(bodyParser.urlencoded({ extended: false }));
@@ -32,28 +33,31 @@ app.use(function (req, res, next) {
 });
 
 app.listen(PORT, function () {
-    console.log('Vault UI listening on: ' + PORT);
+    console.log('Vault UI listening at ' + HTTP_PREFIX + ' on: ' + PORT);
 });
 
-app.post('/wrap', function(req,res) {
+app.post(prefixPath('/wrap'), function(req,res) {
     routeHandler.wrapValue(req, res);
 });
 
-app.post('/unwrap', function(req, res) {
+app.post(prefixPath('/unwrap'), function(req, res) {
     routeHandler.unwrapValue(req, res);
 })
 
-app.all('/v1/*', function(req, res, _next) {
+app.all(prefixPath('/v1/*'), function(req, res, _next) {
     routeHandler.vaultapi(req, res);
 })
 
-app.get('/');
+app.get(prefixPath('/'));
 
-app.get('*', function (req, res) {
+app.get(prefixPath('*'), function (req, res) {
     res.render(path.join(__dirname, '/index.html'),{
+        httpPrefix: prefixPath('/').replace(/\/+$/, ''), // no trailing slashes on httpPrefix
         defaultUrl: VAULT_URL_DEFAULT,
         defaultAuth: VAULT_AUTH_DEFAULT,
         suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER ? req.header(VAULT_SUPPLIED_TOKEN_HEADER) : "",
         defaultBackendPath: VAULT_AUTH_BACKEND_PATH
     });
 });
+
+var prefixPath = (path) => { return (HTTP_PREFIX + path).replace(/\/+/g, '/') }


### PR DESCRIPTION
**PR created for code review and feedback from upstream devs**

For our application, we need to be able to run the vault-ui under a given path prefix (http://localhost:8000/my-path/...)

This change adds a HTTP_PREFIX environment variable and prefixed all paths with that string, defaulting to '/'
