### PR TITLE
bumped material-ui version, added sorting dropdown

### DIFF
--- a/app/components/Secrets/Generic/Generic.jsx
+++ b/app/components/Secrets/Generic/Generic.jsx
@@ -465,7 +465,7 @@ class GenericSecretBackend extends React.Component {
                                         {renderBreadcrumb()}
                                     </Stepper>
                                 </Subheader>
-                                <SelectField value={this.state.secretSortDir} onChange={(e,i,v) => {console.log(i); this.setState({secretSortDir: v})}}>
+                                <SelectField value={this.state.secretSortDir} onChange={(e,i,v) => {this.setState({secretSortDir: v})}}>
                                     <MenuItem value={SORT_DIR.ASC} primaryText={SORT_DIR.ASC}/>
                                     <MenuItem value={SORT_DIR.DESC} primaryText={SORT_DIR.DESC}/>
                                 </SelectField>

--- a/app/components/Secrets/Generic/Generic.jsx
+++ b/app/components/Secrets/Generic/Generic.jsx
@@ -10,6 +10,8 @@ import ActionDelete from 'material-ui/svg-icons/action/delete';
 import ActionDeleteForever from 'material-ui/svg-icons/action/delete-forever';
 import IconButton from 'material-ui/IconButton';
 import Divider from 'material-ui/Divider';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem'
 import { List, ListItem } from 'material-ui/List';
 import { Step, Stepper, StepLabel } from 'material-ui/Stepper';
 import sharedStyles from '../../shared/styles.css';
@@ -23,6 +25,10 @@ import JsonEditor from '../../shared/JsonEditor.jsx';
 import SecretWrapper from '../../shared/Wrapping/Wrapper.jsx'
 import { browserHistory, Link } from 'react-router'
 
+const SORT_DIR = {
+    ASC: 'asc',
+    DESC: 'desc'
+};
 
 function snackBarMessage(message) {
     let ev = new CustomEvent("snackbar", { detail: { message: message } });
@@ -40,6 +46,7 @@ class GenericSecretBackend extends React.Component {
 
         this.state = {
             newSecretBtnDisabled: true,
+            secretSortDir: SORT_DIR.ASC,
             secretList: [],
             secretContent: {},
             newSecretName: '',
@@ -358,7 +365,8 @@ class GenericSecretBackend extends React.Component {
 
     render() {
         let renderSecretListItems = (returndirs, returnobjs) => {
-            return _.map(this.state.secretList, (key) => {
+            let sortedSecrets = _.orderBy(this.state.secretList, _.identity, this.state.secretSortDir);
+            return _.map(sortedSecrets, (key) => {
                 let avatar = (<Avatar icon={<ActionAssignment />} />);
                 let action = (
                     <IconButton
@@ -457,6 +465,10 @@ class GenericSecretBackend extends React.Component {
                                         {renderBreadcrumb()}
                                     </Stepper>
                                 </Subheader>
+                                <SelectField value={this.state.secretSortDir} onChange={(e,i,v) => {console.log(i); this.setState({secretSortDir: v})}}>
+                                    <MenuItem value={SORT_DIR.ASC} primaryText={SORT_DIR.ASC}/>
+                                    <MenuItem value={SORT_DIR.DESC} primaryText={SORT_DIR.DESC}/>
+                                </SelectField>
                                 <Divider inset={false} />
                                 {renderSecretListItems(true, false)}
                                 <Divider inset={true} />

--- a/app/components/Secrets/Generic/Generic.jsx
+++ b/app/components/Secrets/Generic/Generic.jsx
@@ -454,6 +454,16 @@ class GenericSecretBackend extends React.Component {
                                         }}
                                     />
                                 </ToolbarGroup>
+                                <ToolbarGroup lastChild={true}>
+                                    <SelectField
+                                        floatingLabelText="Sort Secrets"
+                                        floatingLabelFixed={true}
+                                        value={this.state.secretSortDir} onChange={(e,i,v) => {this.setState({secretSortDir: v})}}
+                                    >
+                                        <MenuItem value={SORT_DIR.ASC} primaryText="Ascending"/>
+                                        <MenuItem value={SORT_DIR.DESC} primaryText="Descending"/>
+                                    </SelectField>
+                                </ToolbarGroup>
                             </Toolbar>
                             <List className={sharedStyles.listStyle}>
                                 <Subheader inset={false}>
@@ -465,10 +475,6 @@ class GenericSecretBackend extends React.Component {
                                         {renderBreadcrumb()}
                                     </Stepper>
                                 </Subheader>
-                                <SelectField value={this.state.secretSortDir} onChange={(e,i,v) => {this.setState({secretSortDir: v})}}>
-                                    <MenuItem value={SORT_DIR.ASC} primaryText={SORT_DIR.ASC}/>
-                                    <MenuItem value={SORT_DIR.DESC} primaryText={SORT_DIR.DESC}/>
-                                </SelectField>
                                 <Divider inset={false} />
                                 {renderSecretListItems(true, false)}
                                 <Divider inset={true} />

--- a/app/components/Secrets/Generic/Generic.jsx
+++ b/app/components/Secrets/Generic/Generic.jsx
@@ -456,6 +456,8 @@ class GenericSecretBackend extends React.Component {
                                 </ToolbarGroup>
                                 <ToolbarGroup lastChild={true}>
                                     <SelectField
+                                        style={{width: 150}}
+                                        autoWidth={true}
                                         floatingLabelText="Sort Secrets"
                                         floatingLabelFixed={true}
                                         value={this.state.secretSortDir} onChange={(e,i,v) => {this.setState({secretSortDir: v})}}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "immutability-helper": "^2.1.2",
     "jsoneditor": "^5.5.11",
     "lodash": "^4.16.6",
-    "material-ui": "^0.16.1",
+    "material-ui": "^0.16.7",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-router": "^3.0.0",


### PR DESCRIPTION
This solves https://github.com/djenriquez/vault-ui/issues/67

I also bumped the version of material-ui to 0.16.7  - no breaking changes but there was a fix for some `hoveredStyle` error being thrown in the console that was bugging me.

![screen shot 2017-03-30 at 10 59 53 pm](https://cloud.githubusercontent.com/assets/2498352/24538208/a033a17c-159c-11e7-997c-8e93ad210033.png)
