### PR TITLE
Mount Description

### DIFF
--- a/app/components/shared/Menu/Menu.jsx
+++ b/app/components/shared/Menu/Menu.jsx
@@ -130,11 +130,22 @@ class Menu extends React.Component {
                     config: backend.config
                 }
 
+                let secondaryText = (
+                    <p>
+                        {backend.description &&
+                            <span className={styles.mountSecondaryText}>{backend.description}<br /></span>
+                        }
+                        <span className={styles.mountSecondaryText}>type: {backend.type}</span>
+                    </p>
+                )
+
                 return (
                     <ListItem
                         key={idx}
+                        className={styles.menuItem}
                         primaryText={backend.path}
-                        secondaryText={`type: ${backend.type}`}
+                        secondaryText={secondaryText}
+                        secondaryTextLines={backend.description ? 2 : 1}
                         value={`/secrets/${backend.type}/${backend.path}`}
                         rightIconButton={
                             <IconButton
@@ -158,11 +169,22 @@ class Menu extends React.Component {
                     config: backend.config
                 }
 
+                let secondaryText = (
+                    <p>
+                        {backend.description &&
+                            <span className={styles.mountSecondaryText}>{backend.description}<br /></span>
+                        }
+                        <span className={styles.mountSecondaryText}>type: {backend.type}</span>
+                    </p>
+                )
+
                 return (
                     <ListItem
                         key={idx}
+                        className={styles.menuItem}
                         primaryText={backend.path}
-                        secondaryText={`type: ${backend.type}`}
+                        secondaryText={secondaryText}
+                        secondaryTextLines={backend.description ? 2 : 1}
                         value={`/auth/${backend.type}/${backend.path}`}
                         rightIconButton={
                             <IconButton
@@ -227,6 +249,7 @@ class Menu extends React.Component {
                 <Drawer containerClassName={styles.root} docked={true} open={true} >
                     <SelectableList value={this.state.selectedPath} onChange={handleMenuChange}>
                         <ListItem
+                            className={styles.menuItem}
                             primaryText="Secret Backends"
                             primaryTogglesNestedList={true}
                             initiallyOpen={true}
@@ -235,13 +258,14 @@ class Menu extends React.Component {
                                 <IconButton
                                     style={{ opacity: 0.1 }}
                                     hoveredStyle={{ opacity: 1.0 }}
-                                    onTouchTap={() => this.setState({openNewSecretMountDialog: true})}
+                                    onTouchTap={() => this.setState({ openNewSecretMountDialog: true })}
                                 >
                                     <ContentAdd />
                                 </IconButton>
                             }
                         />
                         <ListItem
+                            className={styles.menuItem}
                             primaryText="Auth Backends"
                             primaryTogglesNestedList={true}
                             initiallyOpen={true}
@@ -250,7 +274,7 @@ class Menu extends React.Component {
                                 <IconButton
                                     style={{ opacity: 0.1 }}
                                     hoveredStyle={{ opacity: 1.0 }}
-                                    onTouchTap={() => this.setState({openNewAuthMountDialog: true})}
+                                    onTouchTap={() => this.setState({ openNewAuthMountDialog: true })}
                                 >
                                     <ContentAdd />
                                 </IconButton>
@@ -258,15 +282,17 @@ class Menu extends React.Component {
 
                         />
                         <ListItem
+                            className={styles.menuItem}
                             primaryText="System"
                             primaryTogglesNestedList={true}
                             initiallyOpen={true}
                             nestedItems={[
-                                <ListItem primaryText="Policies" secondaryText="Manage Vault Access Policies" value="/sys/policies" />,
-                                <ListItem primaryText="Data Wrapper" secondaryText="Securely Forward JSON Data" value="/responsewrapper" />
+                                <ListItem className={styles.menuItem} primaryText="Policies" secondaryText="Manage Vault Access Policies" value="/sys/policies" />,
+                                <ListItem className={styles.menuItem} primaryText="Data Wrapper" secondaryText="Securely Forward JSON Data" value="/responsewrapper" />
                             ]}
                         />
                         <ListItem
+                            className={styles.menuItem}
                             primaryText="Preferences"
                             secondaryText="Customize Vault-UI"
                             primaryTogglesNestedList={false}

--- a/app/components/shared/Menu/menu.css
+++ b/app/components/shared/Menu/menu.css
@@ -4,9 +4,9 @@
     height: calc(100% - 60px) !important;
 }
 
-.root span {
-    font-size: 20px !important;
-    font-weight: 200 !important;
+.menuItem > div > div > div {
+    font-size: 20px;
+    font-weight: 250;
 }
 
 .link {
@@ -31,4 +31,11 @@
 
 .disabled {
     display: none;
+}
+
+.mountSecondaryText {
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/app/components/shared/MountUtils/NewMount.jsx
+++ b/app/components/shared/MountUtils/NewMount.jsx
@@ -122,6 +122,15 @@ export default class NewMountDialog extends Component {
                                     onChange={(e) => this.setState({ backendPath: e.target.value }) }
                                 />
                             </div>
+                            <div>
+                                <TextField
+                                    floatingLabelFixed={true}
+                                    floatingLabelText="Mount description"
+                                    fullWidth={true}
+                                    value={this.state.backendDescription}
+                                    onChange={(e) => this.setState({ backendDescription: e.target.value }) }
+                                />
+                            </div>
                         </div>
                     </Dialog >
                 }

--- a/app/components/shared/styles.css
+++ b/app/components/shared/styles.css
@@ -4,10 +4,6 @@
     font-style: italic;
 }
 
-.descriptionField {
-    text-align: center;
-}
-
 .TabContentSection {
     padding: 10px;
 }

--- a/app/components/shared/styles.css
+++ b/app/components/shared/styles.css
@@ -4,6 +4,10 @@
     font-style: italic;
 }
 
+.descriptionField {
+    text-align: center;
+}
+
 .TabContentSection {
     padding: 10px;
 }


### PR DESCRIPTION
Reference: https://github.com/djenriquez/vault-ui/issues/102

This PR adds a description field to the generic secret mount display. Currently, Vault does not have the ability to update the description of a mount (https://github.com/hashicorp/vault/issues/2645), but the logic for it is stubbed in here for when that feature does exist. I realized after doing the work that you can't "re-post" a mount to update, lame.