### PR TITLE
Add ability to show current token + renew lease

### DIFF
--- a/app/components/Authentication/Token/Token.jsx
+++ b/app/components/Authentication/Token/Token.jsx
@@ -415,7 +415,6 @@ export default class TokenAuthBackend extends React.Component {
             >
                 <div>
                     <JsonEditor
-                        height={'300px'}
                         rootName={`auth/token/accessors/${this.state.selectedAccessor}`}
                         value={this.state.accessorDetails[this.state.selectedAccessor]}
                         mode={'view'}

--- a/app/components/Authentication/Token/Token.jsx
+++ b/app/components/Authentication/Token/Token.jsx
@@ -413,12 +413,15 @@ export default class TokenAuthBackend extends React.Component {
                 open={this.state.accessorInfoDialog}
                 onRequestClose={() => this.setState({ accessorInfoDialog: false })}
             >
-                <JsonEditor
-                    rootName={`auth/token/accessors/${this.state.selectedAccessor}`}
-                    value={this.state.accessorDetails[this.state.selectedAccessor]}
-                    mode={'view'}
-                    modes={['view']}
-                />
+                <div>
+                    <JsonEditor
+                        height={'300px'}
+                        rootName={`auth/token/accessors/${this.state.selectedAccessor}`}
+                        value={this.state.accessorDetails[this.state.selectedAccessor]}
+                        mode={'view'}
+                        modes={['view']}
+                    />
+                </div>
             </Dialog>
         )
     }

--- a/app/components/shared/Header/Header.jsx
+++ b/app/components/shared/Header/Header.jsx
@@ -7,6 +7,16 @@ import Github from 'mui-icons/fontawesome/github';
 import CountDown from './countdown.js'
 import styles from './header.css';
 import { callVaultApi, history } from '../../shared/VaultUtils.jsx';
+import IconMenu from 'material-ui/IconMenu';
+import MenuItem from 'material-ui/MenuItem';
+import NavigationMenu from 'material-ui/svg-icons/navigation/menu';
+import Divider from 'material-ui/Divider';
+import Dialog from 'material-ui/Dialog';
+import TextField from 'material-ui/TextField';
+import sharedStyles from '../styles.css';
+import RaisedButton from 'material-ui/RaisedButton';
+import ContentContentCopy from 'material-ui/svg-icons/content/content-copy';
+import copy from 'copy-to-clipboard';
 
 var logout = () => {
     window.localStorage.removeItem('vaultAccessToken');
@@ -23,8 +33,15 @@ class Header extends React.Component {
         super(props);
         this.state = {
             serverAddr: window.localStorage.getItem('vaultUrl'),
-            version: ''
+            version: '',
+            tokenDialogOpened: false,
+            tokenRenewed: false,
+            ttl: 0
         }
+        _.bindAll(
+            this,
+            'renewTokenLease'
+        );
     }
 
     static propTypes = {
@@ -49,7 +66,42 @@ class Header extends React.Component {
             });
     }
 
+    renewTokenLease() {
+        callVaultApi('post', 'auth/token/renew-self')
+            .then((resp) => {
+                snackBarMessage("Session renewed");
+                this.setState({ ttl: resp.data.auth.lease_duration, tokenRenewed: true });
+            })
+            .catch(snackBarMessage)
+    }
+
+
     render() {
+
+        let tokenDialogOptions = [
+            <FlatButton label="Close" primary={true} onTouchTap={() => this.setState({ tokenDialogOpened: false })} />
+        ];
+
+        let showToken = () => {
+            return (
+                <Dialog
+                    title="Token"
+                    modal={true}
+                    open={this.state.tokenDialogOpened}
+                    actions={tokenDialogOptions}
+                >
+                    <div className={sharedStyles.newTokenCodeEmitted}>
+                        <TextField
+                            fullWidth={true}
+                            disabled={true}
+                            floatingLabelText="Token"
+                            defaultValue={window.localStorage.getItem("vaultAccessToken")}
+                        />
+                        <RaisedButton icon={<ContentContentCopy />} label="Copy to Clipboard" onTouchTap={() => { copy(window.localStorage.getItem("vaultAccessToken")) }} />
+                    </div>
+                </Dialog>
+            )
+        }
 
         let renderTokenInfo = () => {
 
@@ -77,7 +129,16 @@ class Header extends React.Component {
                 </span>
             )
 
-            if (this.props.tokenIdentity.ttl) {
+            if (this.state.tokenRenewed) {
+                infoSectionItems.push(
+                        <span key="infoSessionTimeout" className={styles.infoSectionItem}>
+                            <span className={styles.infoSectionItemKey}>token ttl</span>
+                            <span className={styles.infoSectionItemValue}>
+                                <CountDown countDown={this.state.ttl} retrigger={this.props.tokenIdentity.last_renewal_time} />
+                            </span>
+                        </span>
+                    );
+            } else if (this.props.tokenIdentity.ttl) {
                 infoSectionItems.push(
                     <span key="infoSessionTimeout" className={styles.infoSectionItem}>
                         <span className={styles.infoSectionItemKey}>token ttl</span>
@@ -101,34 +162,52 @@ class Header extends React.Component {
         }
 
         return (
-            <div id={styles.headerWrapper}>
-                <Toolbar style={{ backgroundColor: '#000000', height: '64px' }}>
-                    <ToolbarGroup firstChild={true}>
-                        <IconButton
-                            onTouchTap={() => {
-                                if(WEBPACK_DEF_TARGET_WEB) {
-                                    window.open('https://github.com/djenriquez/vault-ui', '_blank');
-                                } else {
-                                    event.preventDefault();
-                                    require('electron').shell.openExternal('https://github.com/djenriquez/vault-ui')
-                                }
-                            }}
-                        >
-                            <Github className={styles.title}/>
-                        </IconButton>
-                        <ToolbarTitle className={styles.title}
-                            onTouchTap={() => {
-                                history.push('/');
-                            }}
-                            text="VAULT - UI" />
-                    </ToolbarGroup>
-                    <ToolbarGroup>
-                        {renderTokenInfo()}
-                    </ToolbarGroup>
-                    <ToolbarGroup lastChild={true}>
-                        <FlatButton className={styles.title} onTouchTap={logout} label="Logout" />
-                    </ToolbarGroup>
-                </Toolbar>
+            <div>
+                {showToken()}
+                <div id={styles.headerWrapper}>
+                    <Toolbar style={{ backgroundColor: '#000000', height: '64px' }}>
+                        <ToolbarGroup firstChild={true}>
+                            <IconButton
+                                onTouchTap={() => {
+                                    if (WEBPACK_DEF_TARGET_WEB) {
+                                        window.open('https://github.com/djenriquez/vault-ui', '_blank');
+                                    } else {
+                                        event.preventDefault();
+                                        require('electron').shell.openExternal('https://github.com/djenriquez/vault-ui')
+                                    }
+                                }}
+                            >
+                                <Github className={styles.title} />
+                            </IconButton>
+                            <ToolbarTitle className={styles.title}
+                                onTouchTap={() => {
+                                    history.push('/');
+                                }}
+                                text="VAULT - UI" />
+                        </ToolbarGroup>
+                        <ToolbarGroup>
+                            {renderTokenInfo()}
+                        </ToolbarGroup>
+                        <ToolbarGroup lastChild={true}>
+                            <IconMenu iconButtonElement={<IconButton ><NavigationMenu color='white' /></IconButton>}>
+                                <MenuItem
+                                    primaryText="Show token"
+                                    onTouchTap={() => this.setState({ tokenDialogOpened: true })}
+                                />
+                                <Divider />
+                                <MenuItem
+                                    primaryText="Renew token lease"
+                                    onTouchTap={this.renewTokenLease}
+                                />
+                                <Divider />
+                                <MenuItem
+                                    primaryText="Logout"
+                                    onTouchTap={logout}
+                                />
+                            </IconMenu>
+                        </ToolbarGroup>
+                    </Toolbar>
+                </div>
             </div>
         )
     }

--- a/app/components/shared/Header/countdown.js
+++ b/app/components/shared/Header/countdown.js
@@ -20,7 +20,7 @@ class CountDown extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if(nextProps.retrigger !== this.props.retrigger) {
+        if (nextProps !== this.props) {
             clearInterval(this.time);
             this.time = nextProps.countDown;
             this.stopTime = Date.now() + (nextProps.countDown * 1000)


### PR DESCRIPTION
Per https://github.com/djenriquez/vault-ui/issues/91, new functionality allows users to renew lease at any time from the new UI menu displayed at the top right.

In this menu, users now also have the ability to display the token they are currently using in order to use it for other tools that may require a Vault Token. 

One thing I did notice that many users may become confused with, is the token renew process, which allows tokens to be renewed up to the maximum mount TTL. For a lot of users, their tokens may already be at max, in which case, this feature does nothing. Another thing I noticed is that when leases are renewed, they are automatically renewed to the mount's max TTL, rather then releasing for the initial TTL deployed. Not sure if this is how the Vault project meant to design these processes but this is how Vault works today. There could be other mount settings that can change these behaviors, but not sure what they are currently.

Reference: https://github.com/hashicorp/vault/issues/1079