### PR TITLE
clean yarn cache from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Vault-UI Contributors
 
 ADD . /app
 WORKDIR /app
-RUN yarn install --pure-lockfile --silent && yarn run build-web && npm prune --silent --production
+RUN yarn install --pure-lockfile --silent && yarn run build-web && npm prune --silent --production && yarn cache clean
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Vault-UI Contributors
 
 ADD . /app
 WORKDIR /app
-RUN yarn install --pure-lockfile --silent && yarn run build-web && npm prune --silent --production && yarn cache clean
+RUN yarn install --pure-lockfile --silent && yarn run build-web && npm prune --silent --production && yarn cache clean && rm -f /root/.electron/* 
 
 EXPOSE 8000
 


### PR DESCRIPTION
decrease image size from 248MB to 86MB, remove useless cache