### PR TITLE
Add AWS Auth (IAM) backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 - Add filtering to all lists - https://github.com/djenriquez/vault-ui/pull/106
 - Add pagination to secrets list - https://github.com/djenriquez/vault-ui/pull/110
 - Add JSON diff view to compare updates - https://github.com/djenriquez/vault-ui/pull/84
+- Add ability to renew token - https://github.com/djenriquez/vault-ui/pull/114
+- Add AWS auth backend with IAM - https://github.com/djenriquez/vault-ui/pull/126
 - Allow naming tokens generated from roles
-- Add ability to renew token
 
 ## Bug fixes
 - Fix docker build electron dependency - https://github.com/djenriquez/vault-ui/pull/112

--- a/app/App.jsx
+++ b/app/App.jsx
@@ -14,6 +14,7 @@ import Settings from './components/Settings/Settings.jsx';
 import ResponseWrapper from './components/ResponseWrapper/ResponseWrapper.jsx';
 import TokenAuthBackend from './components/Authentication/Token/Token.jsx';
 import AwsEc2AuthBackend from './components/Authentication/AwsEc2/AwsEc2.jsx';
+import AwsAuthBackend from './components/Authentication/Aws/Aws.jsx';
 import GithubAuthBackend from './components/Authentication/Github/Github.jsx';
 import RadiusAuthBackend from './components/Authentication/Radius/Radius.jsx';
 import UserPassAuthBackend from './components/Authentication/UserPass/UserPass.jsx';
@@ -78,6 +79,7 @@ ReactDOM.render((
             <Route path="/" component={App} onEnter={checkAccessToken}>
                 <Route path="/secrets/generic/:namespace(/**)" component={SecretsGeneric} />
                 <Route path="/auth/token/:namespace" component={TokenAuthBackend} />
+                <Route path="/auth/aws/:namespace(/**)" component={AwsAuthBackend} />
                 <Route path="/auth/aws-ec2/:namespace(/**)" component={AwsEc2AuthBackend} />
                 <Route path="/auth/github/:namespace(/**)" component={GithubAuthBackend} />
                 <Route path="/auth/radius/:namespace(/**)" component={RadiusAuthBackend} />

--- a/app/components/Authentication/Aws/Aws.jsx
+++ b/app/components/Authentication/Aws/Aws.jsx
@@ -656,7 +656,7 @@ export default class AwsAuthBackend extends React.Component {
                         disabled={!this.state.isBackendConfigured}
                     >
                         <Paper className={sharedStyles.TabInfoSection} zDepth={0}>
-                            Here you can configure EC2 roles.
+                            Here you can configure AWS roles.
                         </Paper>
                         <Paper className={sharedStyles.TabContentSection} zDepth={0}>
                             <Toolbar>
@@ -701,7 +701,7 @@ export default class AwsAuthBackend extends React.Component {
                         onActive={() => this.setState({ selectedTab: 'backend' })}
                     >
                         <Paper className={sharedStyles.TabInfoSection} zDepth={0}>
-                            Here you can configure connection details to your EC2 account.
+                            Here you can configure connection details to your AWS account.
                         </Paper>
                         <Paper className={sharedStyles.TabContentSection} zDepth={0}>
                             <List>

--- a/app/components/Authentication/Aws/Aws.jsx
+++ b/app/components/Authentication/Aws/Aws.jsx
@@ -1,0 +1,743 @@
+import React, { PropTypes } from 'react';
+// Material UI
+import Dialog from 'material-ui/Dialog';
+import TextField from 'material-ui/TextField';
+import IconButton from 'material-ui/IconButton';
+import { Tabs, Tab } from 'material-ui/Tabs';
+import Paper from 'material-ui/Paper';
+import { List, ListItem } from 'material-ui/List';
+import FlatButton from 'material-ui/FlatButton';
+import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
+import Subheader from 'material-ui/Subheader';
+import ActionAccountBox from 'material-ui/svg-icons/action/account-box';
+import ActionDelete from 'material-ui/svg-icons/action/delete';
+import ActionDeleteForever from 'material-ui/svg-icons/action/delete-forever';
+import Toggle from 'material-ui/Toggle';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+// Styles
+import styles from './aws.css';
+import sharedStyles from '../../shared/styles.css';
+import { red500 } from 'material-ui/styles/colors.js';
+import { callVaultApi, tokenHasCapabilities, history } from '../../shared/VaultUtils.jsx';
+// Misc
+import _ from 'lodash';
+import update from 'immutability-helper';
+import Avatar from 'material-ui/Avatar';
+import PolicyPicker from '../../shared/PolicyPicker/PolicyPicker.jsx'
+import VaultObjectDeleter from '../../shared/DeleteObject/DeleteObject.jsx'
+
+function snackBarMessage(message) {
+    document.dispatchEvent(new CustomEvent('snackbar', { detail: { message: message } }));
+}
+
+export default class AwsAuthBackend extends React.Component {
+    static propTypes = {
+        params: PropTypes.object.isRequired,
+        location: PropTypes.object.isRequired
+    };
+
+    ec2ConfigSchema = {
+        access_key: '',
+        endpoint: undefined,
+        secret_key: ''
+    };
+
+    authTypes = [
+        { value: 0, type: 'ec2' },
+        { value: 1, type: 'iam' },
+    ]
+
+    inferredEntityTypes = [
+        { value: 0, type: 'ec2_instance' }
+    ]
+
+    roleConfigSchema = {
+        bound_ami_id: undefined,
+        bound_account_id: undefined,
+        bound_region: undefined,
+        bound_vpc_id: undefined,
+        bound_subnet_id: undefined,
+        bound_iam_role_arn: undefined,
+        bound_iam_instance_profile_arn: undefined,
+        role_tag: undefined,
+        role_tag_value: undefined,
+        ttl: undefined,
+        max_ttl: undefined,
+        period: undefined,
+        policies: [],
+        allow_instance_migration: undefined,
+        disallow_reauthentication: false,
+        auth_type: 'ec2',
+        auth_type_value: 0,
+        bound_iam_principal_arn: undefined,
+        inferred_entity_type: undefined,
+        inferred_aws_region: undefined
+    };
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            baseUrl: `/auth/aws/${this.props.params.namespace}/`,
+            baseVaultPath: `auth/${this.props.params.namespace}`,
+            ec2Roles: [],
+            filteredEc2RoleList: [],
+            configObj: this.ec2ConfigSchema,
+            newConfigObj: this.ec2ConfigSchema,
+            newRoleConfig: this.roleConfigSchema,
+            selectedRoleId: '',
+            newSecretBtnDisabled: false,
+            openNewRoleDialog: false,
+            openEditRoleDialog: false,
+            deleteUserPath: '',
+            selectedTab: 'roles',
+            isBackendConfigured: false
+        };
+
+        _.bindAll(
+            this,
+            'listEc2Roles',
+            'getEc2AuthConfig',
+            'createUpdateConfig',
+            'createUpdateRole'
+        );
+
+    }
+
+    listEc2Roles() {
+        tokenHasCapabilities(['list'], `${this.state.baseVaultPath}/role`)
+            .then(() => {
+                callVaultApi('get', `${this.state.baseVaultPath}/role`, { list: true }, null)
+                    .then((resp) => {
+                        let roles = _.get(resp, 'data.data.keys', []);
+                        this.setState({ ec2Roles: _.valuesIn(roles), filteredEc2RoleList: _.valuesIn(roles) });
+                    })
+                    .catch((error) => {
+                        if (error.response.status !== 404) {
+                            snackBarMessage(error);
+                        } else {
+                            this.setState({ ec2Roles: [], filteredEc2RoleList: [] });
+                        }
+                    });
+            })
+            .catch(() => {
+                snackBarMessage(new Error('Access denied'));
+            })
+    }
+
+    getEc2AuthConfig() {
+        tokenHasCapabilities(['read'], `${this.state.baseVaultPath}/config/client`)
+            .then(() => {
+                callVaultApi('get', `${this.state.baseVaultPath}/config/client`, null, null)
+                    .then((resp) => {
+                        let config = _.get(resp, 'data.data', this.ec2ConfigSchema);
+                        this.setState({
+                            configObj: config,
+                            newConfigObj: config,
+                            isBackendConfigured: true
+                        });
+                    })
+                    .catch((error) => {
+                        if (error.response.status !== 404) {
+                            snackBarMessage(error);
+                        } else {
+                            error.message = `This backend has not yet been configured`;
+                            history.push(`${this.state.baseUrl}backend`);
+                            this.setState({ selectedTab: 'backend', isBackendConfigured: false });
+                            snackBarMessage(error);
+                        }
+                    });
+            })
+            .catch(() => {
+                snackBarMessage(new Error('Access denied'));
+            });
+    }
+
+    createUpdateConfig() {
+        tokenHasCapabilities(['update'], `${this.state.baseVaultPath}/config/client`)
+            .then(() => {
+                callVaultApi('post', `${this.state.baseVaultPath}/config/client`, null, this.state.newConfigObj)
+                    .then(() => {
+                        snackBarMessage(`Backend ${this.state.baseVaultPath}/config has been updated`);
+                        this.setState({ isBackendConfigured: true, configObj: this.state.newConfigObj });
+                    })
+                    .catch(snackBarMessage);
+            })
+            .catch(() => {
+                snackBarMessage(new Error('Access denied'));
+            });
+    }
+
+    createUpdateRole() {
+        let roleId = this.state.selectedRoleId;
+        tokenHasCapabilities(['create', 'update'], `${this.state.baseVaultPath}/role/${roleId}`)
+            .then(() => {
+                let updateObj = _.clone(this.state.newRoleConfig);
+                updateObj.policies = updateObj.policies.join(',');
+
+                // This field is not allowed for IAM types
+                if(updateObj.auth_type === 'iam') {
+                    updateObj.disallow_reauthentication = undefined;
+                    updateObj.allow_instance_migration = undefined;
+                }
+
+                callVaultApi('post', `${this.state.baseVaultPath}/role/${roleId}`, null, updateObj)
+                    .then(() => {
+                        if (updateObj.role_tag && updateObj.role_tag_value) {
+                            callVaultApi('post', `${this.state.baseVaultPath}/role/${roleId}/tag`, null, updateObj.role_tag_value)
+                                .then(() => {
+                                    snackBarMessage(`Role ${roleId} and role tag ${updateObj.role_tag}:${updateObj.role_tag_value} have been updated`);
+                                });
+                        }
+                        else {
+                            snackBarMessage(`Role ${roleId} has been updated`);
+                        }
+                        this.listEc2Roles();
+                        this.setState({ openNewRoleDialog: false, openEditRoleDialog: false, newRoleConfig: _.clone(this.roleConfigSchema), selectedRoleId: '' });
+                        history.push(`${this.state.baseUrl}roles/`);
+                    })
+                    .catch(snackBarMessage);
+            })
+            .catch(() => {
+                this.setState({ selectedRoleId: '' })
+                snackBarMessage(new Error(`No permissions to display properties for role ${this.state.selectedRoleId}`));
+            });
+    }
+
+    displayRole() {
+        let roleId = this.state.selectedRoleId;
+        tokenHasCapabilities(['read'], `${this.state.baseVaultPath}/role/${roleId}`)
+            .then(() => {
+                callVaultApi('get', `${this.state.baseVaultPath}/role/${roleId}`, null, null)
+                    .then((resp) => {
+                        let roleConfig = _.get(resp, 'data.data', {});
+                        roleConfig.auth_type_value = _.get(_.find(this.authTypes, ['type', roleConfig.auth_type]), 'value', 'ec2');
+                        this.setState({ newRoleConfig: roleConfig, openEditRoleDialog: true });
+                    })
+                    .catch(snackBarMessage)
+            })
+            .catch(() => {
+                this.setState({ selectedRoleId: '' })
+                snackBarMessage(new Error(`No permissions to display properties for role ${this.state.selectedRoleId}`));
+            })
+    }
+
+    componentWillMount() {
+        let tab = this.props.location.pathname.split(this.state.baseUrl)[1];
+        if (!tab) {
+            history.push(`${this.state.baseUrl}${this.state.selectedTab}/`);
+        } else {
+            this.setState({ selectedTab: tab.includes('/') ? tab.split('/')[0] : tab });
+        }
+    }
+
+    componentDidMount() {
+        this.listEc2Roles();
+        this.getEc2AuthConfig();
+        let uri = this.props.location.pathname.split(this.state.baseUrl)[1];
+        if (uri.includes('roles/') && uri.split('roles/')[1]) {
+            this.setState({ selectedRoleId: uri.split('roles/')[1] });
+        }
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (this.state.selectedRoleId != prevState.selectedRoleId && !this.state.openNewRoleDialog) {
+            this.listEc2Roles();
+            if (this.state.selectedRoleId) {
+                this.displayRole();
+            }
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (!_.isEqual(this.props.params.namespace, nextProps.params.namespace)) {
+            // Reset
+            this.setState({
+                baseUrl: `/auth/aws/${nextProps.params.namespace}/`,
+                baseVaultPath: `auth/${nextProps.params.namespace}`,
+                ec2Roles: [],
+                filteredEc2RoleList: [],
+                selectedRoleId: '',
+                newConfigObj: this.ec2ConfigSchema,
+                configObj: this.ec2ConfigSchema,
+                selectedTab: 'roles'
+            }, () => {
+                this.listEc2Roles();
+                this.getEc2AuthConfig();
+            });
+        }
+    }
+
+    render() {
+        let renderFields = () => {
+            let renderIamField = () => {
+                return (
+                    [
+                        <TextField
+                            className={styles.textFieldStyle}
+                            hintText='Enter the new role name'
+                            floatingLabelFixed={true}
+                            floatingLabelText='Bound IAM Principle ARN'
+                            value={this.state.newRoleConfig.bound_iam_principal_arn}
+                            fullWidth={false}
+                            autoFocus
+                            onChange={(e) => {
+                                this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_iam_principal_arn: { $set: e.target.value } }) });
+                            }}
+                        />,
+                        <TextField
+                            className={styles.textFieldStyle}
+                            hintText='Enter the EC2 IAM Profile AWS region'
+                            floatingLabelFixed={true}
+                            floatingLabelText='Inferred AWS Region'
+                            value={this.state.newRoleConfig.inferred_aws_region}
+                            fullWidth={false}
+                            autoFocus
+                            onChange={(e) => {
+                                this.setState({ newRoleConfig: update(this.state.newRoleConfig, { inferred_aws_region: { $set: e.target.value } }) });
+                            }}
+                        />
+                    ]
+                )
+            };
+
+            let renderMenuItems = () => {
+                return this.authTypes.map((authType) => (
+                    <MenuItem
+                        value={authType.value}
+                        primaryText={authType.type}
+                    />
+                ));
+            };
+
+            let authTypeChanged = (event, index, value) => {
+                let auth_type = _.get(_.find(this.authTypes, ['value', value]), 'type', 'ec2');
+
+                this.setState(
+                    {
+                        newRoleConfig: update(this.state.newRoleConfig,
+                            {
+                                auth_type: { $set: auth_type },
+                                auth_type_value: { $set: value },
+                                disallow_reauthentication: { $set: auth_type === 'iam' ? undefined : this.state.disallow_reauthentication },
+                                inferred_entity_type: {$set: auth_type === 'iam' ? 'ec2_instance': undefined },
+                                inferred_aws_region: {$set: auth_type === 'iam' ? this.state.inferred_aws_region : undefined }
+                            }),
+
+                    });
+            };
+
+            return (
+                <List>
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='Enter the new role name'
+                        floatingLabelFixed={true}
+                        floatingLabelText='Role Name'
+                        fullWidth={false}
+                        value={this.state.selectedRoleId}
+                        disabled={this.state.openEditRoleDialog}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ selectedRoleId: e.target.value });
+                        }}
+                    />
+                    <SelectField
+                        floatingLabelText="Auth Type"
+                        value={this.state.newRoleConfig.auth_type_value}
+                        onChange={authTypeChanged}
+                    >
+                        {renderMenuItems()}
+                    </SelectField>
+                    {this.state.newRoleConfig.auth_type === "iam" && renderIamField()}
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='Role Tag Key'
+                        disabled={this.state.newRoleConfig.auth_type === 'iam'}
+                        value={this.state.newRoleConfig.role_tag}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { role_tag: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='overwrite current value'
+                        floatingLabelFixed={true}
+                        floatingLabelText='Role Tag Value'
+                        disabled={this.state.newRoleConfig.auth_type === 'iam'}
+                        value={this.state.newRoleConfig.role_tag_value}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { role_tag_value: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='AMI ID'
+                        value={this.state.newRoleConfig.bound_ami_id}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_ami_id: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='IAM Role ARN'
+                        value={this.state.newRoleConfig.bound_iam_role_arn}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_iam_role_arn: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='Account ID'
+                        value={this.state.newRoleConfig.bound_account_id}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_account_id: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='Region'
+                        value={this.state.newRoleConfig.bound_region}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_region: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='VPC ID'
+                        value={this.state.newRoleConfig.bound_vpc_id}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_vpc_id: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='Subnet ID'
+                        value={this.state.newRoleConfig.bound_subnet_id}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_subnet_id: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='IAM Instance Profile ARN'
+                        value={this.state.newRoleConfig.bound_iam_instance_profile_arn}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { bound_iam_instance_profile_arn: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='TTL'
+                        value={this.state.newRoleConfig.ttl}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { ttl: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <TextField
+                        className={styles.textFieldStyle}
+                        hintText='optional'
+                        floatingLabelFixed={true}
+                        floatingLabelText='Max TTL'
+                        value={this.state.newRoleConfig.max_ttl}
+                        fullWidth={false}
+                        autoFocus
+                        onChange={(e) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { max_ttl: { $set: e.target.value } }) });
+                        }}
+                    />
+                    <ListItem primaryText='Disallow Reauthentication'>
+                        <Toggle
+                            toggled={this.state.newRoleConfig.disallow_reauthentication}
+                            onToggle={(e, v) => {
+                                this.setState({ newRoleConfig: update(this.state.newRoleConfig, { disallow_reauthentication: { $set: v } }) });
+                            }}
+                        />
+                    </ListItem>
+                    <Subheader>Assigned Policies</Subheader>
+                    <PolicyPicker
+                        height='200px'
+                        selectedPolicies={this.state.newRoleConfig.policies}
+                        onSelectedChange={(newPolicies) => {
+                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { policies: { $set: newPolicies } }) });
+                        }}
+                    />
+                </List>
+            )
+        }
+
+        let renderRoleListItems = () => {
+            return _.map(this.state.filteredEc2RoleList, (role) => {
+                let avatar = (<Avatar icon={<ActionAccountBox />} />);
+                let action = (
+                    <IconButton
+                        tooltip='Delete'
+                        onTouchTap={() => this.setState({ deleteUserPath: `${this.state.baseVaultPath}/role/${role}` })}
+                    >
+                        {window.localStorage.getItem('showDeleteModal') === 'false' ? <ActionDeleteForever color={red500} /> : <ActionDelete color={red500} />}
+                    </IconButton>
+                );
+
+                let item = (
+                    <ListItem
+                        key={role}
+                        primaryText={role}
+                        insetChildren={true}
+                        leftAvatar={avatar}
+                        rightIconButton={action}
+                        onTouchTap={() => {
+                            tokenHasCapabilities(['read'], `${this.state.baseVaultPath}/role/${role}`)
+                                .then(() => {
+                                    this.setState({ selectedRoleId: role });
+                                    history.push(`${this.state.baseUrl}roles/${role}`);
+                                }).catch(() => {
+                                    snackBarMessage(new Error('Access denied'));
+                                })
+
+                        }}
+                    />
+                )
+                return item;
+            });
+        }
+
+        let renderNewRoleDialog = () => {
+            let validateAndSubmit = () => {
+                if (this.state.selectedRoleId === '') {
+                    snackBarMessage(new Error('Role name cannot be empty'));
+                    return;
+                }
+
+                if (_.indexOf(this.state.ec2Roles, this.state.selectedRoleId) > 0) {
+                    snackBarMessage(new Error('Role already exists'));
+                    return;
+                }
+
+                this.createUpdateRole();
+            }
+
+            const actions = [
+                <FlatButton
+                    label='Cancel'
+                    onTouchTap={() => {
+                        this.setState({ openNewRoleDialog: false });
+                    }}
+                />,
+                <FlatButton
+                    label='Create'
+                    primary={true}
+                    onTouchTap={validateAndSubmit}
+                />
+            ];
+
+
+
+            return (
+                <Dialog
+                    title={`Register EC2 role`}
+                    modal={false}
+                    actions={actions}
+                    open={this.state.openNewRoleDialog}
+                    onRequestClose={() => this.setState({ openNewRoleDialog: false })}
+                    autoScrollBodyContent={true}
+                >
+                    {renderFields()}
+                </Dialog>
+            );
+        }
+
+        let renderEditRoleDialog = () => {
+            const actions = [
+                <FlatButton
+                    label='Cancel'
+                    onTouchTap={() => {
+                        this.setState({ openEditRoleDialog: false, selectedRoleId: '' })
+                        history.push(`${this.state.baseUrl}roles/`);
+                    }}
+                />,
+                <FlatButton
+                    label='Save'
+                    primary={true}
+                    onTouchTap={() => {
+                        this.createUpdateRole()
+                    }}
+                />
+            ];
+
+            return (
+                <Dialog
+                    title={`Editing role ${this.state.selectedRoleId}`}
+                    modal={false}
+                    actions={actions}
+                    open={this.state.openEditRoleDialog}
+                    onRequestClose={() => {
+                        this.setState({ openEditRoleDialog: false, selectedRoleId: '' });
+                        history.push(`${this.state.baseUrl}roles/`);
+                    }}
+                    autoScrollBodyContent={true}
+                >
+                    {renderFields()}
+                </Dialog>
+            );
+        }
+
+        return (
+            <div>
+                {this.state.openEditRoleDialog && renderEditRoleDialog()}
+                {this.state.openNewRoleDialog && renderNewRoleDialog()}
+                <VaultObjectDeleter
+                    path={this.state.deleteUserPath}
+                    onReceiveResponse={() => {
+                        snackBarMessage(`Object '${this.state.deleteUserPath}' deleted`)
+                        this.setState({ deleteUserPath: '' })
+                        this.listEc2Roles();
+                    }}
+                    onReceiveError={(err) => snackBarMessage(err)}
+                />
+                <Tabs
+                    onChange={(e) => {
+                        history.push(`${this.state.baseUrl}${e}/`);
+                        this.setState({ newConfigObj: _.clone(this.state.configObj) });
+                    }}
+                    value={this.state.selectedTab}
+                >
+                    <Tab
+                        label='Manage Roles'
+                        value='roles'
+                        onActive={() => this.setState({ selectedTab: 'roles' })}
+                        disabled={!this.state.isBackendConfigured}
+                    >
+                        <Paper className={sharedStyles.TabInfoSection} zDepth={0}>
+                            Here you can configure EC2 roles.
+                        </Paper>
+                        <Paper className={sharedStyles.TabContentSection} zDepth={0}>
+                            <Toolbar>
+                                <ToolbarGroup firstChild={true}>
+                                    <FlatButton
+                                        primary={true}
+                                        label='NEW ROLE'
+                                        disabled={this.state.newSecretBtnDisabled}
+                                        onTouchTap={() => {
+                                            this.setState({
+                                                openNewRoleDialog: true,
+                                                newRoleConfig: _.clone(this.roleConfigSchema)
+                                            })
+                                        }}
+                                    />
+                                </ToolbarGroup>
+                                <ToolbarGroup lastChild={true}>
+                                    <TextField
+                                        floatingLabelFixed={true}
+                                        floatingLabelText="Filter"
+                                        hintText="Filter list items"
+                                        onChange={(e, v) => {
+                                            let filtered = _.filter(this.state.ec2Roles, (item) => {
+                                                return item.toLowerCase().includes(v.toLowerCase());
+                                            });
+                                            if (filtered.length > 0)
+                                                this.setState({
+                                                    filteredEc2RoleList: filtered
+                                                });
+                                        }}
+                                    />
+                                </ToolbarGroup>
+                            </Toolbar>
+                            <List className={sharedStyles.listStyle}>
+                                {renderRoleListItems()}
+                            </List>
+                        </Paper>
+                    </Tab>
+                    <Tab
+                        label='Configure Backend'
+                        value='backend'
+                        onActive={() => this.setState({ selectedTab: 'backend' })}
+                    >
+                        <Paper className={sharedStyles.TabInfoSection} zDepth={0}>
+                            Here you can configure connection details to your EC2 account.
+                        </Paper>
+                        <Paper className={sharedStyles.TabContentSection} zDepth={0}>
+                            <List>
+                                <TextField
+                                    hintText='AKIAIOSFODNN7EXAMPLE'
+                                    floatingLabelText='AWS Access Key ID'
+                                    fullWidth={true}
+                                    floatingLabelFixed={true}
+                                    value={this.state.newConfigObj.access_key}
+                                    onChange={(e) => {
+                                        this.setState({ newConfigObj: update(this.state.newConfigObj, { access_key: { $set: e.target.value } }) });
+                                    }}
+                                />
+                                <TextField
+                                    hintText='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+                                    floatingLabelText='AWS Secret Access Key'
+                                    fullWidth={true}
+                                    type='password'
+                                    floatingLabelFixed={true}
+                                    value={this.state.newConfigObj.secret_key}
+                                    onChange={(e) => {
+                                        this.setState({ newConfigObj: update(this.state.newConfigObj, { secret_key: { $set: e.target.value } }) });
+                                    }}
+                                />
+                                <TextField
+                                    hintText='Override with caution'
+                                    floatingLabelText='Endpoint for making AWS EC2 API calls'
+                                    fullWidth={true}
+                                    floatingLabelFixed={true}
+                                    value={this.state.newConfigObj.endpoint}
+                                    onChange={(e) => {
+                                        this.setState({ newConfigObj: update(this.state.newConfigObj, { endpoint: { $set: e.target.value } }) });
+                                    }}
+                                />
+                                <div style={{ paddingTop: '20px', textAlign: 'center' }}>
+                                    <FlatButton
+                                        primary={true}
+                                        label='Save'
+                                        onTouchTap={() => this.createUpdateConfig()}
+                                    />
+                                </div>
+                            </List>
+                        </Paper>
+                    </Tab>
+                </Tabs>
+            </div >
+        );
+    }
+}

--- a/app/components/Authentication/Aws/Aws.jsx
+++ b/app/components/Authentication/Aws/Aws.jsx
@@ -176,7 +176,7 @@ export default class AwsAuthBackend extends React.Component {
                 updateObj.policies = updateObj.policies.join(',');
 
                 // This field is not allowed for IAM types
-                if(updateObj.auth_type === 'iam') {
+                if (updateObj.auth_type === 'iam') {
                     updateObj.disallow_reauthentication = undefined;
                     updateObj.allow_instance_migration = undefined;
                 }
@@ -270,7 +270,7 @@ export default class AwsAuthBackend extends React.Component {
 
     render() {
         let renderFields = () => {
-            let renderIamField = () => {
+            let renderIamFields = () => {
                 return (
                     [
                         <TextField
@@ -301,6 +301,37 @@ export default class AwsAuthBackend extends React.Component {
                 )
             };
 
+            let renderRoleTagFields = () => {
+                return (
+                    [
+                        <TextField
+                            className={styles.textFieldStyle}
+                            hintText='optional'
+                            floatingLabelFixed={true}
+                            floatingLabelText='Role Tag Key'
+                            value={this.state.newRoleConfig.role_tag}
+                            fullWidth={false}
+                            autoFocus
+                            onChange={(e) => {
+                                this.setState({ newRoleConfig: update(this.state.newRoleConfig, { role_tag: { $set: e.target.value } }) });
+                            }}
+                        />,
+                        <TextField
+                            className={styles.textFieldStyle}
+                            hintText='overwrite current value'
+                            floatingLabelFixed={true}
+                            floatingLabelText='Role Tag Value'
+                            value={this.state.newRoleConfig.role_tag_value}
+                            fullWidth={false}
+                            autoFocus
+                            onChange={(e) => {
+                                this.setState({ newRoleConfig: update(this.state.newRoleConfig, { role_tag_value: { $set: e.target.value } }) });
+                            }}
+                        />
+                    ]
+                )
+            };
+
             let renderMenuItems = () => {
                 return this.authTypes.map((authType) => (
                     <MenuItem
@@ -319,9 +350,12 @@ export default class AwsAuthBackend extends React.Component {
                             {
                                 auth_type: { $set: auth_type },
                                 auth_type_value: { $set: value },
-                                disallow_reauthentication: { $set: auth_type === 'iam' ? undefined : this.state.disallow_reauthentication },
-                                inferred_entity_type: {$set: auth_type === 'iam' ? 'ec2_instance': undefined },
-                                inferred_aws_region: {$set: auth_type === 'iam' ? this.state.inferred_aws_region : undefined }
+                                disallow_reauthentication: { $set: auth_type === 'ec2' ? this.state.disallow_reauthentication : undefined },
+                                role_tag: { $set: auth_type === 'ec2' ? this.state.role_tag : undefined },
+                                role_tag_value: { $set: auth_type === 'ec2' ? this.state.role_tag_value : undefined },
+                                bound_iam_principal_arn: { $set: auth_type === 'iam' ? this.state.bound_iam_principal_arn : undefined },
+                                inferred_entity_type: { $set: auth_type === 'iam' ? 'ec2_instance' : undefined },
+                                inferred_aws_region: { $set: auth_type === 'iam' ? this.state.inferred_aws_region : undefined }
                             }),
 
                     });
@@ -346,36 +380,12 @@ export default class AwsAuthBackend extends React.Component {
                         floatingLabelText="Auth Type"
                         value={this.state.newRoleConfig.auth_type_value}
                         onChange={authTypeChanged}
+                        disabled={this.state.openEditRoleDialog}
                     >
                         {renderMenuItems()}
                     </SelectField>
-                    {this.state.newRoleConfig.auth_type === "iam" && renderIamField()}
-                    <TextField
-                        className={styles.textFieldStyle}
-                        hintText='optional'
-                        floatingLabelFixed={true}
-                        floatingLabelText='Role Tag Key'
-                        disabled={this.state.newRoleConfig.auth_type === 'iam'}
-                        value={this.state.newRoleConfig.role_tag}
-                        fullWidth={false}
-                        autoFocus
-                        onChange={(e) => {
-                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { role_tag: { $set: e.target.value } }) });
-                        }}
-                    />
-                    <TextField
-                        className={styles.textFieldStyle}
-                        hintText='overwrite current value'
-                        floatingLabelFixed={true}
-                        floatingLabelText='Role Tag Value'
-                        disabled={this.state.newRoleConfig.auth_type === 'iam'}
-                        value={this.state.newRoleConfig.role_tag_value}
-                        fullWidth={false}
-                        autoFocus
-                        onChange={(e) => {
-                            this.setState({ newRoleConfig: update(this.state.newRoleConfig, { role_tag_value: { $set: e.target.value } }) });
-                        }}
-                    />
+                    {this.state.newRoleConfig.auth_type === "iam" && renderIamFields()}
+                    {this.state.newRoleConfig.auth_type === "ec2" && renderRoleTagFields()}
                     <TextField
                         className={styles.textFieldStyle}
                         hintText='optional'

--- a/app/components/Authentication/Aws/aws.css
+++ b/app/components/Authentication/Aws/aws.css
@@ -1,0 +1,4 @@
+.error {
+    color: #f44336;
+    margin: 20px 0;
+}

--- a/app/components/shared/Menu/Menu.jsx
+++ b/app/components/shared/Menu/Menu.jsx
@@ -21,7 +21,8 @@ const supported_auth_backend_types = [
     'github',
     'radius',
     'aws-ec2',
-    'userpass'
+    'userpass',
+    'aws'
 ]
 
 function snackBarMessage(message) {


### PR DESCRIPTION
# Summary
This adds the new `aws` auth backend, which is distinct from `aws-ec2`, see [docs](https://www.vaultproject.io/docs/auth/aws.html). The `aws` backend offers the `iam` auth type but is otherwise identical to the `aws-ec2 backend. This feature is only available for users who use Vault > 0.7.1. Users who attempt to enable `aws` for older versions of Vault will receive an error. The `aws-ec2` backend is still functional and will remain functional subject to the version of Vault being used.

## Notes
- Some clean up and refactoring of code from aws-ec2, otherwise, mostly copied
- Styling was not prioritized _at all_ for this PR
- Enabled the [role_tag feature](https://www.vaultproject.io/docs/auth/aws.html#dynamic-management-of-policies-via-role-tags). Only available in `ec2` auth types.
- Fixed bug with existing properties not populating for some fields

## References
- https://github.com/djenriquez/vault-ui/issues/121