### PR TITLE
Colorful jsondiff as default, optional annotations

### DIFF
--- a/app/components/App/App.jsx
+++ b/app/components/App/App.jsx
@@ -99,6 +99,9 @@ export default class App extends React.Component {
         if (!window.localStorage.getItem('enableCapabilitiesCache')) {
             window.localStorage.setItem('enableCapabilitiesCache', 'true');
         }
+        if (!window.localStorage.getItem('enableDiffAnnotations')) {
+            window.localStorage.setItem('enableDiffAnnotations', 'false');
+        }
         document.addEventListener("snackbar", (e) => {
             let messageStyle = { backgroundColor: green500 };
             let message = e.detail.message.toString();

--- a/app/components/Settings/Settings.jsx
+++ b/app/components/Settings/Settings.jsx
@@ -33,6 +33,10 @@ class Settings extends React.Component {
         });
     }
 
+    setDiffAnnotationsPreference(e, isChecked) {
+        window.localStorage.setItem('enableDiffAnnotations', isChecked);
+    }
+
     setCapCachePreference(e, isChecked) {
         window.localStorage.setItem('enableCapabilitiesCache', isChecked);
     }
@@ -61,6 +65,10 @@ class Settings extends React.Component {
                                     label="Enable capabilities cache"
                                     onCheck={this.setCapCachePreference}
                                     defaultChecked={window.localStorage.getItem('enableCapabilitiesCache') === 'true'} />
+                                <Checkbox
+                                    label="Display annotations for JSON diff"
+                                    onCheck={this.setDiffAnnotationsPreference}
+                                    defaultChecked={window.localStorage.getItem('enableDiffAnnotations') === 'true'} />
                             </div>
                             <div>
                                 <h2>Secrets</h2>

--- a/app/components/shared/JsonEditor.jsx
+++ b/app/components/shared/JsonEditor.jsx
@@ -94,7 +94,7 @@ class JsonEditor extends React.Component {
                 <JsonDiffReact
                     left={this.state.initialValue}
                     right={this.props.value}
-                    annotated={true}
+                    annotated={window.localStorage.getItem("enableDiffAnnotations") === "true"}
                 />
             );
         }


### PR DESCRIPTION
Added a setting "Display annotations for JSON diff" and made it false by default. I think most people would prefer the "visual" formatter vs the "annotated" formatter. Take a look!