### PR TITLE
Specify a self-signed CA Certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,16 @@ FROM node:7-alpine
 
 MAINTAINER Vault-UI Contributors
 
-ADD . /app
 WORKDIR /app
-RUN yarn install --pure-lockfile --silent && yarn run build-web && npm prune --silent --production && yarn cache clean && rm -f /root/.electron/* 
+COPY . .
+
+RUN yarn install --pure-lockfile --silent && \
+    yarn run build-web && \
+    npm prune --silent --production && \
+    yarn cache clean && \
+    rm -f /root/.electron/*
 
 EXPOSE 8000
 
-CMD ["yarn", "run", "serve"]
+ENTRYPOINT ["./bin/entrypoint.sh"]
+CMD ["start_app"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ djenriquez/vault-ui
 ```
 
 Supported environment variables:
+- `CUSTOM_CA_CERT` Pass a self-signed certificate that the system should trust
 - `NODE_TLS_REJECT_UNAUTHORIZED` disable TLS server side validation (ex. vault deployed with self-signed certificate)
 - `VAULT_URL_DEFAULT` will set the default vault endpoint.
 - `VAULT_AUTH_DEFAULT` will set the default authentication method type. See below for supported authentication methods.
@@ -161,7 +162,7 @@ Users have the ability to create and revoke tokens, manage token roles and list 
   "path": {
      "auth/token/accessors": {
        "capabilities": [
-         "sudo", 
+         "sudo",
          "list"
        ]
     },

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [[ ! -z "$CUSTOM_CA_CERT" ]]; then
+  echo "$CUSTOM_CA_CERT" > misc/custom_ca.crt
+  export NODE_EXTRA_CA_CERTS=misc/custom_ca.crt
+fi
+
+if [ "$1" = 'start_app' ]; then
+  exec yarn run serve "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This PR lets anyone pass a self-signed certificate as a runtime environment variable using `CUSTOM_CA_CERT`. This is a much better solution than ignoring TLS rejections.

Previously this could only be accomplished by building your child image, copying the cert, and specifying `NODE_EXTRA_CA_CERTS`. With this PR users won't have to build and host their own images just to use a self-signed CA.

I also updated the Dockerfile to use an ENTRYPOINT instead of CMD, based on the [best practices guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#entrypoint). This lets you start the app by default, but easily pass `/bin/sh` or any other command to docker run instead. It also lets us trust the CA cert before starting the app.

Let me know any thoughts/feedback. Thanks.