### PR TITLE
Upgrade base image to node:8.1.4-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7-alpine
+FROM node:8.1.4-alpine
 
 MAINTAINER Vault-UI Contributors
 
@@ -7,7 +7,9 @@ COPY . .
 
 RUN yarn install --pure-lockfile --silent && \
     yarn run build-web && \
-    npm prune --silent --production && \
+    yarn install --silent --production && \
+    yarn check --verify-tree --production && \
+    yarn global add nodemon && \
     yarn cache clean && \
     rm -f /root/.electron/*
 

--- a/app/components/Authentication/Github/Github.jsx
+++ b/app/components/Authentication/Github/Github.jsx
@@ -535,7 +535,7 @@ export default class GithubAuthBackend extends React.Component {
                                     floatingLabelText='GitHub endpoint'
                                     fullWidth={true}
                                     floatingLabelFixed={true}
-                                    value={this.state.newConfig.endpoint}
+                                    value={this.state.newConfig.base_url}
                                     onChange={(e) => {
                                         this.setState({ newConfig: update(this.state.newConfig, { endpoint: { $set: e.target.value } }) });
                                     }}


### PR DESCRIPTION
```
yarn global add nodemon
```
can avoid this issue https://github.com/yarnpkg/yarn/issues/3531

But I found another issue:
```
yarn run v0.24.6
$ nodemon ./server.js start_app
[nodemon] 1.11.0
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: *.*
[nodemon] starting `node ./server.js start_app`
module.js:487
    throw err;
    ^

Error: Cannot find module 'express'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/app/server.js:3:15)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
```
so, all commands should be:
```
yarn install --silent --production
yarn check --verify-tree --production
yarn global add nodemon
```