### PR TITLE
Replace HCL parsing library

### DIFF
--- a/app/components/Policies/Manage.jsx
+++ b/app/components/Policies/Manage.jsx
@@ -12,7 +12,7 @@ import Dialog from 'material-ui/Dialog';
 import TextField from 'material-ui/TextField';
 import IconButton from 'material-ui/IconButton';
 import JsonEditor from '../shared/JsonEditor.jsx';
-import hcltojson from 'hcl-to-json'
+import ghcl from 'gopher-hcl';
 import jsonschema from './vault-policy-schema.json'
 import { callVaultApi, tokenHasCapabilities, history } from '../shared/VaultUtils.jsx'
 import Avatar from 'material-ui/Avatar';
@@ -266,7 +266,7 @@ export default class PolicyManager extends React.Component {
 
                 if (!rules_obj) {
                     // Previous parse failed, attempt HCL to JSON conversion
-                    rules_obj = hcltojson(rules);
+                    rules_obj = ghcl.parse(rules);
                 }
 
                 if (rules_obj) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "extract-zip": "1.6.0",
     "file-loader": "^0.11.1",
     "flexboxgrid": "^6.3.1",
-    "hcl-to-json": "0.0.4",
+    "gopher-hcl": "^0.1.0",
     "immutability-helper": "^2.1.2",
     "jsondiffpatch": "^0.2.4",
     "jsondiffpatch-for-react": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,7 +2430,7 @@ follow-redirects@^1.2.3:
   dependencies:
     debug "^2.4.5"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -2604,6 +2604,12 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+gopher-hcl@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/gopher-hcl/-/gopher-hcl-0.1.0.tgz#0582a022292ee0a6ba9ac616f9245b5dc2f6314f"
+  dependencies:
+    mixin-deep "^1.2.0"
+
 got@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/got/-/got-3.3.1.tgz#e5d0ed4af55fc3eef4d56007769d98192bcb2eca"
@@ -2694,14 +2700,6 @@ hawk@~3.1.3:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
-
-hcl-to-json@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/hcl-to-json/-/hcl-to-json-0.0.4.tgz#f68255e1ad59ec84be376cf7aec7bad3589baba7"
-  dependencies:
-    debug "^2.2.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
 
 history@^3.0.0:
   version "3.3.0"
@@ -3341,10 +3339,6 @@ lodash.defaults@^3.1.2:
     lodash.assign "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3372,10 +3366,6 @@ lodash.merge@^4.6.0:
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -3543,6 +3533,13 @@ minimist@0.0.8:
 minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+mixin-deep@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.2.0.tgz#d02b8c6f8b6d4b8f5982d3fd009c4919851c3fe2"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^0.1.1"
 
 mkdirp@0.5.0:
   version "0.5.0"


### PR DESCRIPTION
This PR fixes #150 by replacing the `hcl-to-json` library with `gopher-hcl` which handles a dot character in the path section correctly.

`gopher-hcl` acts a drop-in replacement and so it requires minimal code changes