### PR TITLE
allows for server port to be configured via env var PORT

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ var path = require('path');
 var routeHandler = require('./src/routeHandler');
 var compression = require('compression');
 
-var PORT = 8000;
+var PORT = process.env.PORT || 8000;
 
 var app = express();
 app.set('view engine', 'html');


### PR DESCRIPTION
@djenriquez would love to be able to configure what port the server listens on. our setup has a cluster-level router that forwards upstream on 80 via linked docker containers.