### PR TITLE
Bug fix: dashes in breadcrumb break

### DIFF
--- a/app/components/Secrets/Generic/Generic.jsx
+++ b/app/components/Secrets/Generic/Generic.jsx
@@ -323,7 +323,7 @@ export default class GenericSecretBackend extends React.Component {
                     var stepLabelStyle = { paddingLeft: '10px'}
                     var iconContainerStyle = {}
                 }
-                return (<Step key={index}><StepLabel style={Object.assign({paddingRight: '10px', fontSize: '16px'}, stepLabelStyle)} iconContainerStyle={iconContainerStyle} icon={<span />}><Link to={`/secrets/generic/${relativelink}`}>{dir}</Link></StepLabel></Step>)
+                return (<Step key={index}><StepLabel style={Object.assign({paddingRight: '10px', fontSize: '16px'}, stepLabelStyle)} iconContainerStyle={iconContainerStyle} icon={<span />}><Link to={`/secrets/generic/${relativelink}`}>{dir.replace("-",'\u2011')}</Link></StepLabel></Step>)
             });
         }
 


### PR DESCRIPTION
Something about the line-breaking behavior of dashes caused paths with dashes to mess up the spacing of the breacrumb menu. My co-worker @kooroshd helped me figure this one out-- the fix is to replace normal dashes w/ non-breaking dashes. Thanks @kooroshd!