### PR TITLE
Bug fix: breadcrumb spacing for ALL breaking characters

### DIFF
--- a/app/components/Secrets/Generic/Generic.jsx
+++ b/app/components/Secrets/Generic/Generic.jsx
@@ -323,7 +323,7 @@ export default class GenericSecretBackend extends React.Component {
                     var stepLabelStyle = { paddingLeft: '10px'}
                     var iconContainerStyle = {}
                 }
-                return (<Step key={index}><StepLabel style={Object.assign({paddingRight: '10px', fontSize: '16px'}, stepLabelStyle)} iconContainerStyle={iconContainerStyle} icon={<span />}><Link to={`/secrets/generic/${relativelink}`}>{dir.replace("-",'\u2011')}</Link></StepLabel></Step>)
+                return (<Step key={index}><StepLabel style={Object.assign({paddingRight: '10px', fontSize: '16px', whiteSpace: 'nowrap'}, stepLabelStyle)} iconContainerStyle={iconContainerStyle} icon={<span />}><Link to={`/secrets/generic/${relativelink}`}>{dir}</Link></StepLabel></Step>)
             });
         }
 


### PR DESCRIPTION
#186 only fixed the improper breadcrumb spacing that occurred when dashes were used. The fix did not address spaces. This fix addresses both.