### PR TITLE
Upgrade node to 8.5, remove deprecated MAINTAINER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:8.4.0-alpine
+FROM node:8.5-alpine
 
-MAINTAINER Vault-UI Contributors
+LABEL maintainer="Vault-UI Contributors"
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
# Summary
- Upgrade node to 8.5-alpine. Now uses a repository link with node to build on new node releases.
- Remove deprecated `MAINTAINER` tag

# Reference
https://github.com/djenriquez/vault-ui/issues/184