### PR TITLE
clarifies expected value for VAULT_URL_DEFAULT

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Supported environment variables:
 - `PORT` Sets the port for Vault-UI to listen on. (Default 8000)
 - `CUSTOM_CA_CERT` Pass a self-signed certificate that the system should trust.
 - `NODE_TLS_REJECT_UNAUTHORIZED` Disable TLS server side validation. (ex. vault deployed with self-signed certificate). Set to `0` to disable.
-- `VAULT_URL_DEFAULT` Sets the default vault endpoint.
+- `VAULT_URL_DEFAULT` Sets the default vault endpoint. Note: protocol part of the url is mandatory. Example: http://10.0.0.1:8200
 - `VAULT_AUTH_DEFAULT` Sets the default authentication method type. See below for supported authentication methods.
 - `VAULT_AUTH_BACKEND_PATH` Sets the default backend path. Useful when multiple backends of the same type are mounted on the vault file system.
 - `VAULT_SUPPLIED_TOKEN_HEADER` Instructs Vault-UI to attempt authentication using a token provided by the client in the specified HTTP request header.


### PR DESCRIPTION
Adds a notice to the description of the VAULT_URL_DEFAULT parameter explaining that the protocol part of the url is mandatory. This is a workaround for the unclear error message an user gets if it is missing

workaround for issue #192 