### PR TITLE
Fix the custom_ca.crt specified by CUSTOM_CA_CERT

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [[ ! -z "$CUSTOM_CA_CERT" ]]; then
-  echo "$CUSTOM_CA_CERT" > misc/custom_ca.crt
+  cat $CUSTOM_CA_CERT > misc/custom_ca.crt
   export NODE_EXTRA_CA_CERTS=misc/custom_ca.crt
 fi
 


### PR DESCRIPTION
The `bin/entrypoint.sh` was just copying the location of the custom ca
file from $CUSTOM_CA_CERT into the `misc/custom_ca.crt`.
This copies the contents of the file specified in $CUSTOM_CA_CERT into
`misc/custom_ca.crt` as I assume was originally intended in PR #140 ?

NOTE: the node.js [documentation](https://nodejs.org/api/cli.html?cm_mc_uid=81661334622515060239383&cm_mc_sid_50200000=1506624063#cli_node_extra_ca_certs_file)