### PR TITLE
Fix Desktop Login

### DIFF
--- a/index.desktop.html
+++ b/index.desktop.html
@@ -5,7 +5,7 @@
         <title>Vault-UI</title>
         <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet">
         <link href="dist/styles.css" rel="stylesheet">
-        <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+        <link rel="shortcut icon" href="dist/favicon.ico" type="image/x-icon">
         <style type="text/css">
             body {
                 font-family: 'Source Sans Pro', sans-serif;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = function (env) {
         },
         output: {
             path: path.resolve(__dirname, './dist'),
-            publicPath: '/dist/',
+            publicPath: env.target == 'electron' ? 'dist/' : '/dist/',
             filename: buildfor + '-bundle.js'
         },
         module: {


### PR DESCRIPTION
# Summary
The desktop electron app was incorrectly loading the Vault-UI logo on the login page. This PR corrects that.
<img width="1025" alt="screen shot 2017-09-30 at 11 10 57 am" src="https://user-images.githubusercontent.com/4636740/31048388-dd064176-a5d0-11e7-8ec5-50f4f2f4f98d.png">

# Reference
- #157