### PR TITLE
Bug fix: Create Token button disabled

### DIFF
--- a/app/components/Authentication/Token/Token.jsx
+++ b/app/components/Authentication/Token/Token.jsx
@@ -347,13 +347,13 @@ export default class TokenAuthBackend extends React.Component {
                         // User doesnt have sudo, use user assigned policies
                         let p1 = callVaultApi('get', 'auth/token/lookup-self').then((resp) => {
                             this.setState({ newTokenAvailablePolicies: resp.data.data.policies });
-                        }).catch(); // <- This shouldnt have failed
+                        }).catch(() => {}); // <- This shouldnt have failed
 
                         // Altough sudo was not granted, we could still create orphans using a different endpoint
                         let p2 = tokenHasCapabilities(['update'], 'auth/token/create-orphan').then(() => {
                             // Turns out we can
                             this.setState({ 'canCreateOrphan': 'create_orphan' });
-                        }).catch(); // <- Nothing we can really do at this point
+                        }).catch(() => {}); // <- Nothing we can really do at this point
 
                         return Promise.all([p1, p2]);
                     });


### PR DESCRIPTION
Fixes #205

Weirdly, catch() w/ no arguments doesn't resolve the promise, it rejects it. So I had a token w/out access to auth/token/create-orphan, and while the button was enabled, it was disabled again in the catch block.

This fixes the issue. @djenriquez have you experienced this behavior? Weirdly, just putting the empty anonymous function as the catch argument fixed it. I want to make sure I'm not crazy here, not a JS guru at all :)