### PR TITLE
Add logic to handle supplied auth token header

### DIFF
--- a/src/vaultui.js
+++ b/src/vaultui.js
@@ -9,15 +9,15 @@ var VAULT_AUTH_BACKEND_PATH_FORCE = process.env.VAULT_AUTH_BACKEND_PATH_FORCE ? 
 var VAULT_SUPPLIED_TOKEN_HEADER = process.env.VAULT_SUPPLIED_TOKEN_HEADER
 
 exports.vaultuiHello = function (req, res) {
-    let response = {
-        defaultVaultUrl: VAULT_URL_DEFAULT,
-        defaultVaultUrlForce: VAULT_URL_DEFAULT_FORCE,
-        defaultAuthMethod: VAULT_AUTH_DEFAULT,
-        defaultAuthMethodForce: VAULT_AUTH_DEFAULT_FORCE,
-        suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER,
-        defaultBackendPath: VAULT_AUTH_BACKEND_PATH,
-        defaultBackendPathForce: VAULT_AUTH_BACKEND_PATH_FORCE
-    }
+  let response = {
+    defaultVaultUrl: VAULT_URL_DEFAULT,
+    defaultVaultUrlForce: VAULT_URL_DEFAULT_FORCE,
+    defaultAuthMethod: VAULT_AUTH_DEFAULT,
+    defaultAuthMethodForce: VAULT_AUTH_DEFAULT_FORCE,
+    suppliedAuthToken: VAULT_SUPPLIED_TOKEN_HEADER ? req.header(VAULT_SUPPLIED_TOKEN_HEADER) : VAULT_SUPPLIED_TOKEN_HEADER,
+    defaultBackendPath: VAULT_AUTH_BACKEND_PATH,
+    defaultBackendPathForce: VAULT_AUTH_BACKEND_PATH_FORCE
+  }
 
-    res.status(200).send(response);
+  res.status(200).send(response);
 };


### PR DESCRIPTION
# Summary
Fixes issue highlighted https://github.com/djenriquez/vault-ui/issues/39#issuecomment-343361887. It appears the functionality was lost during the electron app build work. This re-introduces the logic to handle the `VAULT_SUPPLIED_TOKEN_HEADER`.

# Reference
- [#39](https://github.com/djenriquez/vault-ui/issues/39#issuecomment-343361887)

