### PR TITLE
Remove nodemon from default run

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -7,6 +7,8 @@ fi
 
 if [ "$1" = 'start_app' ]; then
   exec yarn run serve "$@"
+elif [ "$1" = 'dev' ]; then
+  exec yarn run dev "$@"
 fi
 
 exec "$@"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       NODE_TLS_REJECT_UNAUTHORIZED: 0
       VAULT_URL_DEFAULT: http://vault:8200
       VAULT_AUTH_DEFAULT: USERNAMEPASSWORD
+    command: ["dev"]
 #      VAULT_SUPPLIED_TOKEN_HEADER: 'X-Remote-User'
 
   webpack:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "lint": "eslint .",
     "dist": "build",
-    "serve": "nodemon ./server.js",
+    "serve": "node ./server.js",
+    "dev": "nodemon ./server.js",
     "dev-pack": "webpack -d --env.target=web --hide-modules -w",
     "build-desktop": "webpack -p --env.target=electron --hide-modules",
     "build-web": "webpack -p --env.target=web --hide-modules",


### PR DESCRIPTION
# Summary
Configure docker container to launch Vault-UI via `node` instead of `nodemon` when not running for development.

# Reference
- #226 