### PR TITLE
Mask Token Login TextFields like passwords

### DIFF
--- a/app/components/Login/Login.jsx
+++ b/app/components/Login/Login.jsx
@@ -361,6 +361,7 @@ export default class Login extends React.Component {
                     <TextField
                         fullWidth={true}
                         className="col-xs-12"
+                        type="password"
                         errorText={this.state.errorMessage}
                         hintText="Enter Github token"
                         onKeyDown={this.pressEnter}
@@ -372,6 +373,7 @@ export default class Login extends React.Component {
                     <TextField
                         fullWidth={true}
                         className="col-xs-12"
+                        type="password"
                         errorText={this.state.errorMessage}
                         hintText="Enter token"
                         onKeyDown={this.pressEnter}


### PR DESCRIPTION
Login Tokens should be treated as secrets int the UI. This PR changes the GitHub Token and Vault Token login text fields to password type.