### PR TITLE
Fixes string parsing bug and warnings in run-docker-compose-dev

### DIFF
--- a/run-docker-compose-dev
+++ b/run-docker-compose-dev
@@ -16,23 +16,23 @@ exec_in_vault() {
   echo
 }
 
-exec_in_vault vault auth "$(docker-compose logs vault | grep 'Root Token:' | tail -n 1 | awk '{ print $NF }')"
+exec_in_vault vault login "$(docker-compose logs vault | awk '/Root Token:/ {print $NF;}' | tail -n 1 | sed 's/\x1b\[[0-9;]*m//g')"
 exec_in_vault vault status
-exec_in_vault vault auth-enable userpass
-exec_in_vault vault auth-enable -path=userpass2 userpass
-exec_in_vault vault auth-enable github
-exec_in_vault vault auth-enable radius
-exec_in_vault vault auth-enable -path=awsaccount1 aws-ec2
-exec_in_vault vault auth-enable okta
-exec_in_vault vault auth-enable approle
-exec_in_vault vault auth-enable kubernetes
-exec_in_vault vault policy-write admin /misc/admin.hcl
+exec_in_vault vault auth enable userpass
+exec_in_vault vault auth enable -path=userpass2 userpass
+exec_in_vault vault auth enable github
+exec_in_vault vault auth enable radius
+exec_in_vault vault auth enable -path=awsaccount1 aws-ec2
+exec_in_vault vault auth enable okta
+exec_in_vault vault auth enable approle
+exec_in_vault vault auth enable kubernetes
+exec_in_vault vault policy write admin /misc/admin.hcl
 exec_in_vault vault write auth/userpass/users/test password=test policies=admin
 exec_in_vault vault write auth/userpass2/users/john password=doe policies=admin
 exec_in_vault vault write auth/userpass/users/lame password=lame policies=default
 exec_in_vault vault write auth/radius/users/test password=test policies=admin
 exec_in_vault vault write secret/test somekey=somedata
-exec_in_vault vault mount -path=ultrasecret generic
+exec_in_vault vault secrets enable -path=ultrasecret generic
 exec_in_vault vault write ultrasecret/moretest somekey=somedata
 exec_in_vault vault write ultrasecret/dir1/secret somekey=somedata
 exec_in_vault vault write ultrasecret/dir2/secret somekey=somedata


### PR DESCRIPTION
On my system, I ran into a breaking issue with `run-docker-compose-dev`, where the root token would be fetched from the Docker log with some color control characters at the end (`[0m`):

```
mtak@rubiks:~/dev/vault-ui(master)$ docker-compose logs vault | grep 'Root Token:' | tail -n 1 | awk '{print $NF;}' | hexdump -C
00000000  63 31 30 65 64 65 63 64  2d 37 64 62 38 2d 31 36  |c10edecd-7db8-16|
00000010  62 62 2d 31 32 30 31 2d  64 39 38 30 35 30 62 62  |bb-1201-d98050bb|
00000020  65 38 35 64 1b 5b 30 6d  0a                       |e85d.[0m.|
00000029
```

Resulting in the following error (when running `vault auth $token`):

```
------------- vault auth ef6d13da-60a5-1ef8-72f5-f89d37d20bb3 -------------
WARNING! The "vault auth ARG" command is deprecated and is now a subcommand
for interacting with auth methods. To authenticate locally to Vault, use
"vault login" instead. This backwards compatability will be removed in Vault
0.11 (or later).

Error authenticating: Error looking up token: Configured Vault token contains non-printable characters and cannot be used.
```

This PR fixes this issue by stripping control characters from the token. Also several commands have been updated to avoid deprecation warnings. The command now runs without any warnings or errors: https://gist.github.com/mtak/029a0b8ac4a1568d237bda4d8261d53c

System info (Ubuntu 17.10):
```
mtak@rubiks:~/dev/vault-ui(master)$ docker --version
Docker version 1.13.1, build 092cba3
mtak@rubiks:~/dev/vault-ui(master)$ docker-compose --version
docker-compose version 1.8.0, build unknown
mtak@rubiks:~/dev/vault-ui(master)$ uname -a
Linux rubiks 4.13.0-32-generic #35-Ubuntu SMP Thu Jan 25 09:13:46 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```


